### PR TITLE
Avoid re-parsing arguments in CommandAPIHandler#parseArgument

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIHandler.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIHandler.java
@@ -341,7 +341,7 @@ public class CommandAPIHandler<CommandSourceStack> {
 		// Populate array
 		for (Argument<?> argument : args) {
 			if (argument.isListed()) {
-				argList.add(parseArgument(cmdCtx, argument.getNodeName(), argument, args));
+				argList.add(parseArgument(cmdCtx, argument.getNodeName(), argument, argList.toArray()));
 			}
 		}
 
@@ -360,10 +360,10 @@ public class CommandAPIHandler<CommandSourceStack> {
 	 * @return the standard Bukkit type
 	 * @throws CommandSyntaxException
 	 */
-	Object parseArgument(CommandContext<CommandSourceStack> cmdCtx, String key, Argument<?> value, Argument<?>[] args)
+	Object parseArgument(CommandContext<CommandSourceStack> cmdCtx, String key, Argument<?> value, Object[] previousArgs)
 			throws CommandSyntaxException {
 		if (value.isListed()) {
-			return value.parseArgument(NMS, cmdCtx, key, generatePreviousArguments(cmdCtx, args, key));
+			return value.parseArgument(NMS, cmdCtx, key, previousArgs);
 		} else {
 			return null;
 		}
@@ -842,7 +842,7 @@ public class CommandAPIHandler<CommandSourceStack> {
 
 			Object result;
 			try {
-				result = parseArgument(context, arg.getNodeName(), arg, args);
+				result = parseArgument(context, arg.getNodeName(), arg, previousArguments.toArray());
 			} catch (IllegalArgumentException e) {
 				/*
 				 * Redirected commands don't parse previous arguments properly. Simplest way to


### PR DESCRIPTION
`CommanAPIHandler#parseArgument` is called in two places, `CommandAPIHandler#argsToObjectArr` and `CommandAPIHandler#generatePreviousArguments`. Previously, `parseArgument` called `generatePreviousArguments` to get the objects associated with the previous arguments in case they were needed. Since `generatePreviousArguments` goes back and calls `parseArgument`, this can cause arguments to be parsed multiple times like so:
```
argsToObjectArr -> I need to parse args [1, 2, 3]
1:
    parseArgument -> I need previous args for 1
        generatePreviousArguments -> There are none
    1 is parsed
2:
    pA -> I need previous args for 2
        gPA -> I need to parse arg 1
            pA -> I need previous args for 1
                gPA -> There are none
            1 is parsed
    2 is parsed
3:
    pA  -> I need previous args for 3
        gPA -> I need to parse args 1, 2
            pA -> I need previous args for 1
                gPA -> There are none
            1 is parsed
            pA -> I need previous args for 2
                gPA -> I need to parse arg 1
                    pA -> I need previous args for 1
                        gPA -> There are none
                    1 is parsed
            2 is parsed
    3 is parsed
```
Assuming parsing the same argument gives the same result, this is unnecessary. The repetition can be avoided by building a list of the previously parsed args and passing that directly to `parseArgument`. Since the two methods that call `parseArgument` keep track of these lists anyways, making this change is easy.
With this change, the situation from above now goes like this:
```
argsToObjectArr -> I need to parse args [1, 2, 3]
args: []
1:
    parseArgument -> I have previous args for 1
    1 is parsed
args: [1]
2:
    parseArgument -> I have previous args for 2
    2 is parsed
args: [1, 2]
3:
    parseArgument -> I have previous args for 3
    3 is parsed
args: [1, 2, 3]

return args
```

This change fixes issue #298 since `generatePreviousArgs` is no longer called when running a command, which assumed all arguments had unique names. `CustomArgumentsInfo#previousArgs` now correctly gives all previous arguments, even when an argument with the same nodeName as the CustomArgument exists.