### PR TITLE
isLoaded method

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
@@ -54,6 +54,10 @@ public final class CommandAPI {
 	static Logger logger;
 	private static boolean loaded = false;
 
+	public static boolean isLoaded(){
+		return loaded;
+	}
+
 	/**
 	 * Returns the internal configuration used to manage the CommandAPI
 	 * 


### PR DESCRIPTION
Adds isLoaded method to CommandAPI.java to avoid getting "You've tried to call the CommandAPI's onLoad() method more than once!".