### PR TITLE
Improve ListArgument

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
@@ -20,26 +20,17 @@
  *******************************************************************************/
 package dev.jorel.commandapi.arguments;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-
 import com.mojang.brigadier.LiteralMessage;
-import org.bukkit.command.CommandSender;
-
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import dev.jorel.commandapi.IStringTooltip;
-import dev.jorel.commandapi.StringTooltip;
 import dev.jorel.commandapi.nms.NMS;
+import org.bukkit.command.CommandSender;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.regex.Pattern;
 
 /**
  * An argument that accepts a list of objects
@@ -74,11 +65,9 @@ public class ListArgument<T> extends Argument<List> implements IGreedyArgument {
 				values.add(mapper.apply(object));
 			}
 
-			List<String> currentArgList = new ArrayList<>(List.of(currentArg.split(Pattern.quote(delimiter))));
-
 			if(!allowDuplicates) {
 				// filter out values already given
-				for(String str : currentArgList) {
+				for(String str : currentArg.split(Pattern.quote(delimiter))) {
 					IStringTooltip valueToRemove = null;
 					for(IStringTooltip value : values) {
 						if(value.getSuggestion().equals(str)) {

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
@@ -83,7 +83,7 @@ public class ListArgument<T> extends Argument<List> implements IGreedyArgument {
 
 			// offset builder to just after the last argument
 			if(currentArg.contains(delimiter))
-				builder = builder.createOffset(builder.getStart() + currentArg.lastIndexOf(delimiter) + delimiter.length() + 1);
+				builder = builder.createOffset(builder.getStart() + currentArg.lastIndexOf(delimiter) + delimiter.length());
 
 			// 'values' is a set of all objects that need to be suggested
 			for(IStringTooltip str: values) {

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
@@ -98,7 +98,10 @@ public class ListArgument<T> extends Argument<List> implements IGreedyArgument {
 
 			// 'values' is a set of all objects that need to be suggested
 			for(IStringTooltip str: values) {
-				builder.suggest(str.getSuggestion(), new LiteralMessage(str.getTooltip()));
+				if(str.getTooltip() == null)
+					builder.suggest(str.getSuggestion());
+				else
+					builder.suggest(str.getSuggestion(), new LiteralMessage(str.getTooltip()));
 			}
 
 			return builder.buildFuture();

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
@@ -25,6 +25,7 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.jorel.commandapi.IStringTooltip;
+import dev.jorel.commandapi.StringTooltip;
 import dev.jorel.commandapi.nms.NMS;
 import org.bukkit.command.CommandSender;
 
@@ -65,9 +66,15 @@ public class ListArgument<T> extends Argument<List> implements IGreedyArgument {
 				values.add(mapper.apply(object));
 			}
 
+			String[] splitArguments = currentArg.split(Pattern.quote(delimiter));
+			// if an argument is finished, suggest the deliminator
+			String lastArgument = splitArguments[splitArguments.length - 1];
+			if(!currentArg.endsWith(delimiter) && values.stream().map(IStringTooltip::getSuggestion).anyMatch(lastArgument::equals))
+				values.add(StringTooltip.of(lastArgument + delimiter, null));
+
 			if (!allowDuplicates) {
 				// filter out values already given
-				for (String str : currentArg.split(Pattern.quote(delimiter))) {
+				for (String str : splitArguments) {
 					IStringTooltip valueToRemove = null;
 					for (IStringTooltip value : values) {
 						if (value.getSuggestion().equals(str)) {

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
@@ -61,36 +61,38 @@ public class ListArgument<T> extends Argument<List> implements IGreedyArgument {
 			// This need not be a sorted map because entries in suggestions are
 			// automatically sorted anyway
 			Set<IStringTooltip> values = new HashSet<>();
-			for(T object : supplier.apply(info.sender())) {
+			for (T object : supplier.apply(info.sender())) {
 				values.add(mapper.apply(object));
 			}
 
-			if(!allowDuplicates) {
+			if (!allowDuplicates) {
 				// filter out values already given
-				for(String str : currentArg.split(Pattern.quote(delimiter))) {
+				for (String str : currentArg.split(Pattern.quote(delimiter))) {
 					IStringTooltip valueToRemove = null;
-					for(IStringTooltip value : values) {
-						if(value.getSuggestion().equals(str)) {
+					for (IStringTooltip value : values) {
+						if (value.getSuggestion().equals(str)) {
 							valueToRemove = value;
 							break;
 						}
 					}
-					if(valueToRemove != null) {
+					if (valueToRemove != null) {
 						values.remove(valueToRemove);
 					}
 				}
 			}
 
 			// offset builder to just after the last argument
-			if(currentArg.contains(delimiter))
+			if (currentArg.contains(delimiter))
 				builder = builder.createOffset(builder.getStart() + currentArg.lastIndexOf(delimiter) + delimiter.length());
 
 			// 'values' is a set of all objects that need to be suggested
-			for(IStringTooltip str: values) {
-				if(str.getTooltip() == null)
-					builder.suggest(str.getSuggestion());
-				else
-					builder.suggest(str.getSuggestion(), new LiteralMessage(str.getTooltip()));
+			for (IStringTooltip str : values) {
+				if (str.getSuggestion().startsWith(builder.getRemaining())) {
+					if (str.getTooltip() == null)
+						builder.suggest(str.getSuggestion());
+					else
+						builder.suggest(str.getSuggestion(), new LiteralMessage(str.getTooltip()));
+				}
 			}
 
 			return builder.buildFuture();
@@ -109,23 +111,23 @@ public class ListArgument<T> extends Argument<List> implements IGreedyArgument {
 
 	@Override
 	public <CommandListenerWrapper> List<T> parseArgument(NMS<CommandListenerWrapper> nms,
-			CommandContext<CommandListenerWrapper> cmdCtx, String key, Object[] previousArgs) throws CommandSyntaxException {
+														  CommandContext<CommandListenerWrapper> cmdCtx, String key, Object[] previousArgs) throws CommandSyntaxException {
 		// Get the list of values which this can take
 		Map<IStringTooltip, T> values = new HashMap<>();
-		for(T object : supplier.apply(nms.getCommandSenderFromCSS(cmdCtx.getSource()))) {
+		for (T object : supplier.apply(nms.getCommandSenderFromCSS(cmdCtx.getSource()))) {
 			values.put(mapper.apply(object), object);
 		}
 
-		// If the argument argument's value is in the list of values, include it
+		// If the argument's value is in the list of values, include it
 		List<T> list = new ArrayList<>();
 		String[] strArr = cmdCtx.getArgument(key, String.class).split(Pattern.quote(delimiter));
-		for(String str : strArr) {
+		for (String str : strArr) {
 			// Yes, this isn't an instant lookup HashMap, but this is the best we can do
-			for(IStringTooltip value : values.keySet()) {
-				if(value.getSuggestion().equals(str)) {
-					if(allowDuplicates) {
+			for (IStringTooltip value : values.keySet()) {
+				if (value.getSuggestion().equals(str)) {
+					if (allowDuplicates) {
 						list.add(values.get(value));
-					} else if(!list.contains(values.get(value))) {
+					} else if (!list.contains(values.get(value))) {
 						list.add(values.get(value));
 					}
 				}

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgumentBuilder.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgumentBuilder.java
@@ -1,6 +1,7 @@
 package dev.jorel.commandapi.arguments;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -83,6 +84,18 @@ public class ListArgumentBuilder<T> {
 	 * @return this list argument builder
 	 */
 	public ListArgumentBuilderSuggests withList(Collection<T> list) {
+		return withList(info -> list);
+	}
+
+	/**
+	 * Specifies the list to use to generate suggestions for the list argument
+	 *
+	 * @param array an array of elements to suggest for this list argument
+	 * @return this list argument builder
+	 */
+	@SafeVarargs
+	public final ListArgumentBuilderSuggests withList(T... array) {
+		List<T> list = List.of(array);
 		return withList(info -> list);
 	}
 

--- a/commandapi-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -20,12 +20,13 @@
  *******************************************************************************/
 package dev.jorel.commandapi;
 
-import de.tr7zw.changeme.nbtapi.NBTContainer;
-import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
-import org.bukkit.plugin.java.JavaPlugin;
-
 import java.io.File;
 import java.util.Map.Entry;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import de.tr7zw.changeme.nbtapi.NBTContainer;
+import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 
 public class CommandAPIMain extends JavaPlugin {
 

--- a/commandapi-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -70,16 +70,5 @@ public class CommandAPIMain extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		CommandAPI.onEnable(this);
-
-		new CommandAPICommand("listargument")
-			.withArguments(
-				new ListArgumentBuilder<String>("list", ", ")
-				.allowDuplicates(true)
-				.withList("alice", "bob", "charlie")
-				.withMapper(s -> s)
-				.build()
-			).executes((sender, args) -> {
-				sender.sendMessage(args[0].toString());
-			}).register();
 	}
 }

--- a/commandapi-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -20,16 +20,12 @@
  *******************************************************************************/
 package dev.jorel.commandapi;
 
-import java.io.File;
-import java.util.List;
-import java.util.Map.Entry;
-
-import dev.jorel.commandapi.arguments.ListArgument;
-import dev.jorel.commandapi.arguments.ListArgumentBuilder;
-import org.bukkit.plugin.java.JavaPlugin;
-
 import de.tr7zw.changeme.nbtapi.NBTContainer;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.Map.Entry;
 
 public class CommandAPIMain extends JavaPlugin {
 

--- a/commandapi-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -21,8 +21,11 @@
 package dev.jorel.commandapi;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map.Entry;
 
+import dev.jorel.commandapi.arguments.ListArgument;
+import dev.jorel.commandapi.arguments.ListArgumentBuilder;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import de.tr7zw.changeme.nbtapi.NBTContainer;
@@ -67,5 +70,16 @@ public class CommandAPIMain extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		CommandAPI.onEnable(this);
+
+		new CommandAPICommand("listargument")
+			.withArguments(
+				new ListArgumentBuilder<String>("list", ", ")
+				.allowDuplicates(true)
+				.withList("alice", "bob", "charlie")
+				.withMapper(s -> s)
+				.build()
+			).executes((sender, args) -> {
+				sender.sendMessage(args[0].toString());
+			}).register();
 	}
 }


### PR DESCRIPTION
The focus of this PR is to improve the ListArgument's suggestions. Using brigadier's `SuggestionBuilder#createOffset` items can be suggested one at a time, which makes it more clear what the next item is. If an argument is completed this code also suggests the deliminator, making it clear to the user how the command wants them to separate the arguments.

As a minor addition, the ListArgumentBuilder was given the method `withList(T... array)`, which automatically wraps an array into a list. I think this is cleaner on the developer side since they don't need to put `List.of()` themselves. Regardless, it's just a minor change, so you can keep it or leave it.