### PR TITLE
Throw CommandSyntaxExceptions when ListArgument input is wrong

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
@@ -156,7 +156,7 @@ public class ListArgument<T> extends Argument<List> implements IGreedyArgument {
 			}
 			if(!addedItem) {
 				context.setCursor(cursor);
-				throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownArgument().createWithContext(context);
+				throw new SimpleCommandExceptionType(new LiteralMessage("Item is not allowed in list")).createWithContext(context);
 			}
 			cursor += str.length() + delimiter.length();
 		}

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ListArgument.java
@@ -21,9 +21,11 @@
 package dev.jorel.commandapi.arguments;
 
 import com.mojang.brigadier.LiteralMessage;
+import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import dev.jorel.commandapi.IStringTooltip;
 import dev.jorel.commandapi.StringTooltip;
 import dev.jorel.commandapi.nms.NMS;
@@ -130,18 +132,33 @@ public class ListArgument<T> extends Argument<List> implements IGreedyArgument {
 
 		// If the argument's value is in the list of values, include it
 		List<T> list = new ArrayList<>();
-		String[] strArr = cmdCtx.getArgument(key, String.class).split(Pattern.quote(delimiter));
+		String argument = cmdCtx.getArgument(key, String.class);
+		String[] strArr = argument.split(Pattern.quote(delimiter));
+		StringReader context = new StringReader(argument);
+		int cursor = 0;
 		for (String str : strArr) {
+			boolean addedItem = false;
 			// Yes, this isn't an instant lookup HashMap, but this is the best we can do
 			for (IStringTooltip value : values.keySet()) {
 				if (value.getSuggestion().equals(str)) {
 					if (allowDuplicates) {
 						list.add(values.get(value));
-					} else if (!list.contains(values.get(value))) {
-						list.add(values.get(value));
+					} else {
+						if (!list.contains(values.get(value))) {
+							list.add(values.get(value));
+						} else {
+							context.setCursor(cursor);
+							throw new SimpleCommandExceptionType(new LiteralMessage("Duplicate arguments are not allowed")).createWithContext(context);
+						}
 					}
+					addedItem = true;
 				}
 			}
+			if(!addedItem) {
+				context.setCursor(cursor);
+				throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownArgument().createWithContext(context);
+			}
+			cursor += str.length() + delimiter.length();
 		}
 		return list;
 	}

--- a/commandapi-plugin-test/src/test/java/ArgumentTests.java
+++ b/commandapi-plugin-test/src/test/java/ArgumentTests.java
@@ -1,10 +1,3 @@
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -48,6 +41,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for the 40+ arguments in dev.jorel.commandapi.arguments
@@ -336,13 +331,13 @@ public class ArgumentTests {
 			})
 			.register();
 
-		server.dispatchCommand(sender, "list cat, wolf, axolotl");
-		server.dispatchCommand(sender, "list cat, wolf, axolotl, chicken");
-		server.dispatchCommand(sender, "list axolotl, wolf, chicken, axolotl");
+		server.dispatchCommand(sender, "list cat, wolf, axolotl"); // normal list
+		server.dispatchCommand(sender, "list cat, wolf, axolotl, wolf"); // don't allow duplicates
+		server.dispatchCommand(sender, "list axolotl, wolf, chicken, cat"); // don't allow unknown items
 
 		assertEquals(List.of("cat", "wolf", "axolotl"), type.get());
-		assertEquals(List.of("cat", "wolf", "axolotl"), type.get());
-		assertEquals(List.of("axolotl", "wolf"), type.get());
+		assertNull(type.get());
+		assertNull(type.get());
 		
 		// List argument, with duplicates
 
@@ -357,13 +352,11 @@ public class ArgumentTests {
 			})
 			.register();
 
-		server.dispatchCommand(sender, "listdup cat, wolf, axolotl, cat, wolf");
-		server.dispatchCommand(sender, "listdup cat, wolf, axolotl, chicken, cat");
-		server.dispatchCommand(sender, "listdup axolotl, wolf, chicken, axolotl, axolotl, axolotl, axolotl, axolotl, wolf");
+		server.dispatchCommand(sender, "listdup cat, wolf, axolotl, cat, wolf"); // allow duplicates
+		server.dispatchCommand(sender, "listdup cat, wolf, axolotl, chicken, cat"); // don't allow unknown items
 
 		assertEquals(List.of("cat", "wolf", "axolotl", "cat", "wolf"), type.get());
-		assertEquals(List.of("cat", "wolf", "axolotl", "cat"), type.get());
-		assertEquals(List.of("axolotl", "wolf", "axolotl", "axolotl", "axolotl", "axolotl", "axolotl", "wolf"), type.get());
+		assertNull(type.get());
 
 		// List argument, with a constant list (not using a supplier)
 		
@@ -377,13 +370,13 @@ public class ArgumentTests {
 			})
 			.register();
 
-		server.dispatchCommand(sender, "listconst cat, wolf, axolotl");
-		server.dispatchCommand(sender, "listconst cat, wolf, axolotl, chicken");
-		server.dispatchCommand(sender, "listconst axolotl, wolf, chicken, axolotl");
+		server.dispatchCommand(sender, "listconst cat, wolf, axolotl"); // normal list
+		server.dispatchCommand(sender, "listconst cat, wolf, axolotl, wolf"); // don't allow duplicates
+		server.dispatchCommand(sender, "listconst axolotl, wolf, chicken, cat"); // don't allow unknown items
 
 		assertEquals(List.of("cat", "wolf", "axolotl"), type.get());
-		assertEquals(List.of("cat", "wolf", "axolotl"), type.get());
-		assertEquals(List.of("axolotl", "wolf"), type.get());
+		assertNull(type.get());
+		assertNull(type.get());
 		
 		// List argument using a function
 		
@@ -396,18 +389,18 @@ public class ArgumentTests {
 				type.set((List<String>) args[0]);
 			})
 			.register();
-	
-		server.dispatchCommand(sender, "listfunc cat, wolf, axolotl");
-		server.dispatchCommand(sender, "listfunc cat, wolf, axolotl, chicken");
-		server.dispatchCommand(sender, "listfunc axolotl, wolf, chicken, axolotl");
-		server.dispatchCommand(sender, "listfunc axolotl, wolf, chicken, axolotl, " + sender.getName());
-	
+
+		server.dispatchCommand(sender, "listfunc cat, wolf, axolotl"); // normal list
+		server.dispatchCommand(sender, "listfunc cat, wolf, axolotl, wolf"); // don't allow duplicates
+		server.dispatchCommand(sender, "listfunc axolotl, wolf, chicken, cat"); // don't allow unknown items
+		server.dispatchCommand(sender, "listfunc axolotl, wolf, " + sender.getName()); // sender name
+
 		assertEquals(List.of("cat", "wolf", "axolotl"), type.get());
-		assertEquals(List.of("cat", "wolf", "axolotl"), type.get());
-		assertEquals(List.of("axolotl", "wolf"), type.get());
 		assertEquals(List.of("axolotl", "wolf", sender.getName()), type.get());
+		assertNull(type.get());
+		assertNull(type.get());
 	}
-	
+
 	@Test
 	public void executionTestWithPlayerArgument() {
 		Mut<Player> type = Mut.of();


### PR DESCRIPTION
Adding one last change to the ListArgument I forgot for #319, this PR enforces the ListArgument's syntax by throwing CommandSyntaxExceptions. Previously, the ListArgument would ignore items that weren't in its list and move on. If the list didn't allow duplicates, it would also just add one of each item. Now, a CommandSyntaxException will be thrown in those cases.

I think the changes to the test cases best explain this:
```java
server.dispatchCommand(sender, "list cat, wolf, axolotl"); // normal list
server.dispatchCommand(sender, "list cat, wolf, axolotl, wolf"); // don't allow duplicates
server.dispatchCommand(sender, "list axolotl, wolf, chicken, cat"); // don't allow unknown items
```
This list command does not allow duplicates. The first command works. The second command complains that `wolf` is in the list twice. The third command complains that `chicken` is not a known argument.

I think this way of handling incorrect items in the list is better than the previous method. Before, if a player sent the command `list cat, wolf, axolotl, wolf` and didn't get any errors, they would expect that whatever the command did, it used `wolf` twice. No one would know that the second `wolf` was cut out of the list behind the scenes. Now, that player would get a command error saying `wolf <- Duplicate arguments are not allowed` and understand why the command isn't doing what they thought it should.

I did have to modify the ListArgument tests, and I'm not sure if I did that correctly. When an invalid command is sent I made it check that nothing got through using `assertNull(type.get());`. If there's a better way to check for a command error, you can put that in.