### PR TITLE
Share and simplify ChatPreviewHandler code

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
@@ -230,8 +230,9 @@ public final class CommandAPI {
 	
 			}, plugin);
 			logNormal("Chat preview enabled");
-		} else
+		} else {
 			logNormal("Chat preview is not available");
+		}
 
 		CommandAPIHandler.getInstance().getPaper().registerReloadHandler(plugin);
 	}

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
@@ -229,7 +229,9 @@ public final class CommandAPI {
 				}
 	
 			}, plugin);
-		}
+			logNormal("Chat preview enabled");
+		} else
+			logNormal("Chat preview is not available");
 
 		CommandAPIHandler.getInstance().getPaper().registerReloadHandler(plugin);
 	}

--- a/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
+++ b/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
@@ -1,0 +1,122 @@
+package dev.jorel.commandapi.nms;
+
+import com.mojang.brigadier.ParseResults;
+import com.mojang.brigadier.context.ParsedCommandNode;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import dev.jorel.commandapi.CommandAPIHandler;
+import dev.jorel.commandapi.arguments.PreviewInfo;
+import dev.jorel.commandapi.exceptions.WrapperCommandSyntaxException;
+import dev.jorel.commandapi.wrappers.PreviewableFunction;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.Connection;
+import net.minecraft.network.chat.Component.Serializer;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.protocol.game.ServerboundChatPreviewPacket;
+import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public abstract class NMS_1_19_Common_ChatPreviewHandler extends ChannelDuplexHandler {
+
+	protected final NMS<CommandSourceStack> nms;
+	protected final Plugin plugin;
+	protected final Player player;
+	protected final Connection connection;
+
+	public NMS_1_19_Common_ChatPreviewHandler(NMS<CommandSourceStack> nms, Plugin plugin, Player player) {
+		this.nms = nms;
+		this.plugin = plugin;
+		this.player = player;
+		this.connection = ((CraftPlayer) player).getHandle().connection.connection;
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+		if (msg instanceof ServerboundChatPreviewPacket chatPreview) {
+			// make sure the result is worth consuming here
+			if (!chatPreview.query().isEmpty() && chatPreview.query().charAt(0) == '/') {
+				handleChatPreviewPacket(chatPreview);
+				return;
+			}
+		}
+
+		// Normal packet handling
+		super.channelRead(ctx, msg);
+	}
+
+	protected abstract void handleChatPreviewPacket(ServerboundChatPreviewPacket chatPreview);
+
+	public MutableComponent chatPreviewQueryToJson(String chatPreviewQuery) {
+		// Substring 1 to get rid of the leading /
+		final String fullInput = chatPreviewQuery.substring(1);
+		ParseResults<CommandSourceStack> results = nms.getBrigadierDispatcher().parse(fullInput, nms.getCLWFromCommandSender(this.player));
+
+		// Generate the path for lookup
+		List<String> path = new ArrayList<>();
+		for (ParsedCommandNode<CommandSourceStack> commandNode : results.getContext().getNodes()) {
+			path.add(commandNode.getNode().getName());
+		}
+		Optional<PreviewableFunction<?>> preview = CommandAPIHandler.getInstance().lookupPreviewable(path);
+		if (preview.isEmpty())
+			return null;
+		// Calculate the (argument) input and generate the component to send
+		String input = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1).getRange().get(fullInput);
+
+		final String jsonToSend;
+
+		Object component;
+		try {
+			@SuppressWarnings("rawtypes") final PreviewInfo previewInfo;
+			if (CommandAPIHandler.getInstance().lookupPreviewableLegacyStatus(path)) {
+				BaseComponent[] parsedInput;
+				try {
+					parsedInput = nms.getChat(results.getContext().build(fullInput), path.get(path.size() - 1));
+				} catch (CommandSyntaxException e) {
+					throw new WrapperCommandSyntaxException(e);
+				}
+				previewInfo = new PreviewInfo<>(this.player, input, chatPreviewQuery, parsedInput);
+			} else {
+				Component parsedInput;
+				try {
+					parsedInput = nms.getAdventureChat(results.getContext().build(fullInput), path.get(path.size() - 1));
+				} catch (CommandSyntaxException e) {
+					throw new WrapperCommandSyntaxException(e);
+				}
+				previewInfo = new PreviewInfo<>(this.player, input, chatPreviewQuery, parsedInput);
+			}
+
+			component = preview.get().generatePreview(previewInfo);
+		} catch (WrapperCommandSyntaxException e) {
+			component = TextComponent.fromLegacyText(e.getMessage() == null ? "" : e.getMessage());
+		}
+
+		if (component != null) {
+			if (component instanceof BaseComponent[] baseComponent) {
+				jsonToSend = ComponentSerializer.toString(baseComponent);
+			} else if (CommandAPIHandler.getInstance().getPaper().isPresent()) {
+				if (component instanceof Component adventureComponent) {
+					jsonToSend = GsonComponentSerializer.gson().serialize(adventureComponent);
+				} else {
+					throw new IllegalArgumentException("Unexpected type returned from chat preview, got: " + component.getClass().getSimpleName());
+				}
+			} else {
+				throw new IllegalArgumentException("Unexpected type returned from chat preview, got: " + component.getClass().getSimpleName());
+			}
+		} else {
+			throw new NullPointerException("Returned value from chat preview was null");
+		}
+
+		return Serializer.fromJson(jsonToSend);
+	}
+}

--- a/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
+++ b/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
@@ -82,8 +82,9 @@ public abstract class NMS_1_19_Common_ChatPreviewHandler extends ChannelDuplexHa
 			path.add(commandNode.getNode().getName());
 		}
 		Optional<PreviewableFunction<?>> preview = CommandAPIHandler.getInstance().lookupPreviewable(path);
-		if (preview.isEmpty())
+		if (preview.isEmpty()) {
 			return null;
+		}
 		// Calculate the (argument) input and generate the component to send
 		String input = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1).getRange().get(fullInput);
 

--- a/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
+++ b/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
@@ -129,11 +129,7 @@ public abstract class NMS_1_19_Common_ChatPreviewHandler extends ChannelDuplexHa
 			// Substring 1 to get rid of the leading /
 			final String fullInput = chatPreviewQuery.substring(1);
 
-			CommandAPI.logNormal("Processing input: " + fullInput);
-			if(cachedResult != null && cachedResult.fullInput.equals(fullInput)) {
-				CommandAPI.logNormal("Using cache");
-				return cachedResult;
-			}
+			if(cachedResult != null && cachedResult.fullInput.equals(fullInput)) return cachedResult;
 
 			ParseResults<CommandSourceStack> results = nms.getBrigadierDispatcher().parse(fullInput, nms.getCLWFromCommandSender(player));
 

--- a/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
+++ b/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
@@ -71,7 +71,7 @@ public abstract class NMS_1_19_Common_ChatPreviewHandler extends ChannelDuplexHa
 
 	protected abstract void handleChatPreviewPacket(ServerboundChatPreviewPacket chatPreview);
 
-	public MutableComponent chatPreviewQueryToJson(String chatPreviewQuery) {
+	public MutableComponent parseChatPreviewQuery(String chatPreviewQuery) {
 		// Substring 1 to get rid of the leading /
 		final String fullInput = chatPreviewQuery.substring(1);
 		ParseResults<CommandSourceStack> results = nms.getBrigadierDispatcher().parse(fullInput, nms.getCLWFromCommandSender(this.player));

--- a/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
+++ b/commandapi-nms/commandapi-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common_ChatPreviewHandler.java
@@ -45,9 +45,23 @@ public abstract class NMS_1_19_Common_ChatPreviewHandler extends ChannelDuplexHa
 	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
 		if (msg instanceof ServerboundChatPreviewPacket chatPreview) {
 			// make sure the result is worth consuming here
+			// Is command
 			if (!chatPreview.query().isEmpty() && chatPreview.query().charAt(0) == '/') {
-				handleChatPreviewPacket(chatPreview);
-				return;
+				final String fullInput = chatPreview.query().substring(1);
+				ParseResults<CommandSourceStack> results = nms.getBrigadierDispatcher().parse(fullInput, nms.getCLWFromCommandSender(this.player));
+
+				// Generate the path for lookup
+				List<String> path = new ArrayList<>();
+				for (ParsedCommandNode<CommandSourceStack> commandNode : results.getContext().getNodes()) {
+					path.add(commandNode.getNode().getName());
+				}
+				Optional<PreviewableFunction<?>> preview = CommandAPIHandler.getInstance().lookupPreviewable(path);
+
+				// Is previewable argument
+				if (preview.isPresent()) {
+					handleChatPreviewPacket(chatPreview);
+					return;
+				}
 			}
 		}
 

--- a/commandapi-nms/commandapi-1.19.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_1_R1_ChatPreviewHandler.java
+++ b/commandapi-nms/commandapi-1.19.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_1_R1_ChatPreviewHandler.java
@@ -41,7 +41,7 @@ public class NMS_1_19_1_R1_ChatPreviewHandler extends NMS_1_19_Common_ChatPrevie
 			CompletableFuture<net.minecraft.network.chat.Component> result = new CompletableFuture<>();
 
 			// get preview
-			Bukkit.getScheduler().runTask(this.plugin, () -> result.complete(chatPreviewQueryToJson(chatPreview.query())));
+			Bukkit.getScheduler().runTask(this.plugin, () -> result.complete(parseChatPreviewQuery(chatPreview.query())));
 
 			// update player's ChatPreviewCache
 			result.thenAcceptAsync(component -> {

--- a/commandapi-nms/commandapi-1.19.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_1_R1_ChatPreviewHandler.java
+++ b/commandapi-nms/commandapi-1.19.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_1_R1_ChatPreviewHandler.java
@@ -1,58 +1,28 @@
 package dev.jorel.commandapi.nms;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-
+import dev.jorel.commandapi.preprocessor.RequireField;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.PacketSendListener;
+import net.minecraft.network.chat.ChatPreviewCache;
+import net.minecraft.network.chat.ChatPreviewThrottler;
+import net.minecraft.network.protocol.game.ClientboundChatPreviewPacket;
+import net.minecraft.network.protocol.game.ServerboundChatPreviewPacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-import com.mojang.brigadier.ParseResults;
-import com.mojang.brigadier.context.ParsedCommandNode;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.arguments.PreviewInfo;
-import dev.jorel.commandapi.exceptions.WrapperCommandSyntaxException;
-import dev.jorel.commandapi.preprocessor.RequireField;
-import dev.jorel.commandapi.wrappers.PreviewableFunction;
-import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelHandlerContext;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
-import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.network.Connection;
-import net.minecraft.network.PacketSendListener;
-import net.minecraft.network.chat.ChatPreviewCache;
-import net.minecraft.network.chat.ChatPreviewThrottler;
-import net.minecraft.network.chat.ChatPreviewThrottler.Request;
-import net.minecraft.network.chat.Component.Serializer;
-import net.minecraft.network.protocol.game.ClientboundChatPreviewPacket;
-import net.minecraft.network.protocol.game.ServerboundChatPreviewPacket;
-import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
 
 @RequireField(in = ServerGamePacketListenerImpl.class, name = "chatPreviewCache", ofType = ChatPreviewCache.class)
 @RequireField(in = ServerGamePacketListenerImpl.class, name = "chatPreviewThrottler", ofType = ChatPreviewThrottler.class)
-public class NMS_1_19_1_R1_ChatPreviewHandler extends ChannelDuplexHandler {
-
-	private final NMS<CommandSourceStack> nms;
-	private final Plugin plugin;
-	private final Player player;
-	private final Connection connection;
+public class NMS_1_19_1_R1_ChatPreviewHandler extends NMS_1_19_Common_ChatPreviewHandler {
 	ChatPreviewThrottler throttler;
 
 	public NMS_1_19_1_R1_ChatPreviewHandler(NMS<CommandSourceStack> nms, Plugin plugin, Player player) {
-		this.nms = nms;
-		this.plugin = plugin;
-		this.player = player;
-		this.connection = ((CraftPlayer) player).getHandle().connection.connection;
+		super(nms, plugin, player);
 
 		try {
 			Field f = ServerGamePacketListenerImpl.class.getDeclaredField("M");
@@ -64,121 +34,34 @@ public class NMS_1_19_1_R1_ChatPreviewHandler extends ChannelDuplexHandler {
 	}
 
 	@Override
-	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-		if (msg instanceof ServerboundChatPreviewPacket chatPreview) {
-			if (!chatPreview.query().isEmpty() && chatPreview.query().charAt(0) == '/') {
-				// We want to run this synchronously, just in case there's some funky async
-				// stuff going on here
+	protected void handleChatPreviewPacket(ServerboundChatPreviewPacket chatPreview) {
+		// We want to run this synchronously, just in case there's some funky async stuff going on here
+		throttler.schedule(() -> {
+			int i = chatPreview.queryId();
+			CompletableFuture<net.minecraft.network.chat.Component> result = new CompletableFuture<>();
 
-				throttler.schedule(new Request() {
+			// get preview
+			Bukkit.getScheduler().runTask(this.plugin, () -> result.complete(chatPreviewQueryToJson(chatPreview.query())));
 
-					@Override
-					public CompletableFuture<?> run() {
-						int i = chatPreview.queryId();
-						String s = chatPreview.query();
-
-						return generateComponentToSend(s).thenAccept(component -> {
-							connection.send(new ClientboundChatPreviewPacket(i, component),
-								PacketSendListener.exceptionallySend(() -> new ClientboundChatPreviewPacket(i, null)));
-						});
-					}
-
-				});
-				return;
-			}
-		}
-
-		// Normal packet handling
-		super.channelRead(ctx, msg);
-	}
-
-	@SuppressWarnings("unchecked")
-	private CompletableFuture<net.minecraft.network.chat.Component> generateComponentToSend(String chatPreviewQuery) {
-		CompletableFuture<net.minecraft.network.chat.Component> result = new CompletableFuture<>();
-		
-		Bukkit.getScheduler().runTask(this.plugin, () -> {
-
-			// Substring 1 because we want to get rid of the leading /
-			final String fullInput = chatPreviewQuery.substring(1);
-			ParseResults<CommandSourceStack> results = nms.getBrigadierDispatcher().parse(fullInput, ((CraftPlayer) player).getHandle().createCommandSourceStack());
-
-			// Generate the path for lookup
-			List<String> path = new ArrayList<>();
-			for (ParsedCommandNode<CommandSourceStack> commandNode : results.getContext().getNodes()) {
-				path.add(commandNode.getNode().getName());
-			}
-			Optional<PreviewableFunction<?>> preview = CommandAPIHandler.getInstance().lookupPreviewable(path);
-			if (preview.isPresent()) {
-				// Calculate the (argument) input and generate the component to send
-				String input = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1).getRange().get(fullInput);
-
-				final String jsonToSend;
-
-				Object component = null;
+			// update player's ChatPreviewCache
+			result.thenAcceptAsync(component -> {
 				try {
-					@SuppressWarnings("rawtypes")
-					final PreviewInfo previewInfo;
-					if (CommandAPIHandler.getInstance().lookupPreviewableLegacyStatus(path)) {
-						BaseComponent[] parsedInput = null;
-						try {
-							parsedInput = nms.getChat(results.getContext().build(fullInput), path.get(path.size() - 1));
-						} catch (CommandSyntaxException e) {
-							throw new WrapperCommandSyntaxException(e);
-						}
-						previewInfo = new PreviewInfo<BaseComponent[]>(this.player, input, chatPreviewQuery, parsedInput);
-					} else {
-						Component parsedInput = null;
-						try {
-							parsedInput = nms.getAdventureChat(results.getContext().build(fullInput), path.get(path.size() - 1));
-						} catch (CommandSyntaxException e) {
-							throw new WrapperCommandSyntaxException(e);
-						}
-						previewInfo = new PreviewInfo<Component>(this.player, input, chatPreviewQuery, parsedInput);
-					}
-
-					component = preview.get().generatePreview(previewInfo);
-				} catch (WrapperCommandSyntaxException e) {
-					component = TextComponent.fromLegacyText(e.getMessage() == null ? "" : e.getMessage());
+					Field f = ServerGamePacketListenerImpl.class.getDeclaredField("L");
+					f.setAccessible(true);
+					ChatPreviewCache c = (ChatPreviewCache) f.get(((CraftPlayer) player).getHandle().connection);
+					c.set(chatPreview.query().substring(1), component);
+				} catch (Exception e) {
+					e.printStackTrace();
 				}
+			});
 
-				if (component != null) {
-					if (component instanceof BaseComponent[] baseComponent) {
-						jsonToSend = ComponentSerializer.toString(baseComponent);
-					} else if (CommandAPIHandler.getInstance().getPaper().isPresent()) {
-						if (component instanceof Component adventureComponent) {
-							jsonToSend = GsonComponentSerializer.gson().serialize(adventureComponent);
-						} else {
-							throw new IllegalArgumentException("Unexpected type returned from chat preview, got: " + component.getClass().getSimpleName());
-						}
-					} else {
-						throw new IllegalArgumentException("Unexpected type returned from chat preview, got: " + component.getClass().getSimpleName());
-					}
-				} else {
-					throw new NullPointerException("Returned value from chat preview was null");
-				}
-
-				if (jsonToSend != null) {
-					result.complete(Serializer.fromJson(jsonToSend));
-				}
-			}
-
-			// It seems happy to return null, so we'll do that
-			result.complete(null);
+			// send ChatPreviewPacket
+			return result.thenAccept(
+				component -> connection.send(
+					new ClientboundChatPreviewPacket(i, component),
+					PacketSendListener.exceptionallySend(() -> new ClientboundChatPreviewPacket(i, null))
+				)
+			);
 		});
-
-		result.thenAcceptAsync(component -> {
-			try {
-				Field f = ServerGamePacketListenerImpl.class.getDeclaredField("L");
-				f.setAccessible(true);
-				ChatPreviewCache c = (ChatPreviewCache) f.get(((CraftPlayer) player).getHandle().connection);
-				c.set(chatPreviewQuery.substring(1), component);
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		});
-
-		return result;
-
 	}
-
 }

--- a/commandapi-nms/commandapi-1.19/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_R1_ChatPreviewHandler.java
+++ b/commandapi-nms/commandapi-1.19/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_R1_ChatPreviewHandler.java
@@ -17,7 +17,7 @@ public class NMS_1_19_R1_ChatPreviewHandler extends NMS_1_19_Common_ChatPreviewH
 	protected void handleChatPreviewPacket(ServerboundChatPreviewPacket chatPreview) {
 		// We want to run this synchronously, just in case there's some funky async stuff going on here
 		Bukkit.getScheduler().runTask(this.plugin, () -> this.connection.send(
-			new ClientboundChatPreviewPacket(chatPreview.queryId(), chatPreviewQueryToJson(chatPreview.query()))
+			new ClientboundChatPreviewPacket(chatPreview.queryId(), parseChatPreviewQuery(chatPreview.query()))
 		));
 	}
 }

--- a/commandapi-nms/commandapi-1.19/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_R1_ChatPreviewHandler.java
+++ b/commandapi-nms/commandapi-1.19/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_R1_ChatPreviewHandler.java
@@ -1,125 +1,23 @@
 package dev.jorel.commandapi.nms;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.protocol.game.ClientboundChatPreviewPacket;
+import net.minecraft.network.protocol.game.ServerboundChatPreviewPacket;
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-import com.mojang.brigadier.ParseResults;
-import com.mojang.brigadier.context.ParsedCommandNode;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.arguments.PreviewInfo;
-import dev.jorel.commandapi.exceptions.WrapperCommandSyntaxException;
-import dev.jorel.commandapi.wrappers.PreviewableFunction;
-import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelHandlerContext;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
-import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.network.Connection;
-import net.minecraft.network.chat.Component.Serializer;
-import net.minecraft.network.protocol.game.ClientboundChatPreviewPacket;
-import net.minecraft.network.protocol.game.ServerboundChatPreviewPacket;
-
-public class NMS_1_19_R1_ChatPreviewHandler extends ChannelDuplexHandler {
-
-	private final NMS<CommandSourceStack> nms;
-	private final Plugin plugin;
-	private final Player player;
-	private final Connection connection;
+public class NMS_1_19_R1_ChatPreviewHandler extends NMS_1_19_Common_ChatPreviewHandler {
 
 	public NMS_1_19_R1_ChatPreviewHandler(NMS<CommandSourceStack> nms, Plugin plugin, Player player) {
-		this.nms = nms;
-		this.plugin = plugin;
-		this.player = player;
-		this.connection = ((CraftPlayer) player).getHandle().connection.connection;
+		super(nms, plugin, player);
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-		if (msg instanceof ServerboundChatPreviewPacket chatPreview) {
-			if(!chatPreview.query().isEmpty() && chatPreview.query().charAt(0) == '/') {
-				// We want to run this synchronously, just in case there's some funky async stuff going on here
-				Bukkit.getScheduler().runTask(this.plugin, () -> {
-					// Substring 1 because we want to get rid of the leading /
-					final String fullInput = chatPreview.query().substring(1);
-					ParseResults<CommandSourceStack> results = nms.getBrigadierDispatcher().parse(fullInput, nms.getCLWFromCommandSender(this.player));
-
-					// Generate the path for lookup
-					List<String> path = new ArrayList<>();
-					for (ParsedCommandNode<CommandSourceStack> commandNode : results.getContext().getNodes()) {
-						path.add(commandNode.getNode().getName());
-					}
-					Optional<PreviewableFunction<?>> preview = CommandAPIHandler.getInstance().lookupPreviewable(path);
-					if(preview.isPresent()) {
-						// Calculate the (argument) input and generate the component to send
-						String input = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1).getRange().get(fullInput);
-
-						final String jsonToSend;
-						
-						Object component = null;
-						try {
-							@SuppressWarnings("rawtypes")
-							final PreviewInfo previewInfo;
-							if(CommandAPIHandler.getInstance().lookupPreviewableLegacyStatus(path)) {
-								BaseComponent[] parsedInput = null;
-								try {
-									parsedInput = nms.getChat(results.getContext().build(fullInput), path.get(path.size() - 1));
-								} catch (CommandSyntaxException e) {
-									throw new WrapperCommandSyntaxException(e);
-								}
-								previewInfo = new PreviewInfo<BaseComponent[]>(this.player, input, chatPreview.query(), parsedInput);
-							} else {
-								Component parsedInput = null;
-								try {
-									parsedInput = nms.getAdventureChat(results.getContext().build(fullInput), path.get(path.size() - 1));
-								} catch (CommandSyntaxException e) {
-									throw new WrapperCommandSyntaxException(e);
-								}
-								previewInfo = new PreviewInfo<Component>(this.player, input, chatPreview.query(), parsedInput);
-							}
-
-							component = preview.get().generatePreview(previewInfo);
-						} catch (WrapperCommandSyntaxException e) {
-							component = TextComponent.fromLegacyText(e.getMessage() == null ? "" : e.getMessage());
-						}
-						
-						if(component != null) {
-							if(component instanceof BaseComponent[] baseComponent) {
-								jsonToSend = ComponentSerializer.toString(baseComponent);
-							} else if(CommandAPIHandler.getInstance().getPaper().isPresent()) {
-								if(component instanceof Component adventureComponent) {
-									jsonToSend = GsonComponentSerializer.gson().serialize(adventureComponent);
-								} else {
-									throw new IllegalArgumentException("Unexpected type returned from chat preview, got: " + component.getClass().getSimpleName());
-								}
-							} else {
-								throw new IllegalArgumentException("Unexpected type returned from chat preview, got: " + component.getClass().getSimpleName());
-							}
-						} else {
-							throw new NullPointerException("Returned value from chat preview was null");
-						}
-
-						if (jsonToSend != null) {
-							this.connection.send(new ClientboundChatPreviewPacket(chatPreview.queryId(), Serializer.fromJson(jsonToSend)));
-						}
-					}
-				});
-			}
-		}
-
-		// Normal packet handling
-		super.channelRead(ctx, msg);
+	protected void handleChatPreviewPacket(ServerboundChatPreviewPacket chatPreview) {
+		// We want to run this synchronously, just in case there's some funky async stuff going on here
+		Bukkit.getScheduler().runTask(this.plugin, () -> this.connection.send(
+			new ClientboundChatPreviewPacket(chatPreview.queryId(), chatPreviewQueryToJson(chatPreview.query()))
+		));
 	}
-
 }


### PR DESCRIPTION
The focus of this PR is the added class `NMS_1_19_Common_ChatPreviewHandler`. `NMS_1_19_R1_ChatPreviewHandler` and `NMS_1_19_1_R1_ChatPreviewHandler` extend this class, and it handles things like intercepting chat preview packets and converting the chatPreviewQuery into JSON, which was previously duplicated across those two classes. Along with reorganizing some of the code, these changes saved ~2.4 kB from the plugin jar and made the code easier to understand.

In the future, I think that `NMS_1_19_Common_ChatPreviewHandler` will be able to be adapted for new versions. The only line that looks problematic is 
```java
this.connection = ((CraftPlayer) player).getHandle().connection.connection;
```
which accesses `org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer`. Other than that, subclasses just need to override `handleChatPreviewPacket` to do version-specific field accesses and PreviewChaching or whatever they do with it in the future.

There are two additional changes included here as well:
One, a debug message will now be sent to the console stating whether or not chat preview is active. This is small but useful when messing with chat preview.

Two, the ChatPreviewHandler will check if a previewable argument is currently being filled in before it consumes the chat preview packet. This was an attempt to address this [comment on discord](https://discord.com/channels/745416925924032523/745419648970784821/1009196184377770075) and let chat preview packets that are unrelated to the CommandAPI get processed as normal.

These changes were tested on 1.19 and 1.19.2, and no problems were noticed.