### PR TITLE
Allow suggestions and tooltips to be provided as collections in addition to arrays

### DIFF
--- a/commandapi-core/pom.xml
+++ b/commandapi-core/pom.xml
@@ -46,7 +46,7 @@
 			<groupId>net.kyori</groupId>
 			<artifactId>adventure-platform-bukkit</artifactId>
 			<version>4.1.0</version>
-			<scope>provided</scope>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.papermc.paper</groupId>

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/StringTooltip.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/StringTooltip.java
@@ -24,8 +24,11 @@ import com.mojang.brigadier.Message;
 import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.chat.BaseComponent;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * Represents a suggestion for an argument with a hover tooltip text for that
@@ -113,64 +116,136 @@ public class StringTooltip implements IStringTooltip {
 	}
 	
 	/**
-	 * Constructs an array of {@link StringTooltip} objects from an array of suggestions, and no tooltips
+	 * Constructs a collection of {@link StringTooltip} objects from an array of suggestions, and no tooltips
 	 *
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link StringTooltip} objects from the suggestions, with no tooltips
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the suggestions, with no tooltips
 	 */
-	public static StringTooltip[] none(String... suggestions) {
+	public static Collection<StringTooltip> none(String... suggestions) {
 		return generate(String::toString, (s, t) -> StringTooltip.none(s), suggestions);
 	}
 
 	/**
-	 * Constructs an array of {@link StringTooltip} objects from an array of suggestions,
-	 * and a function which generates a string tooltip for each suggestion
+	 * Constructs a collection of {@link StringTooltip} objects from a collection of suggestions, and no tooltips
+	 *
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the suggestions, with no tooltips
+	 */
+	public static Collection<StringTooltip> none(Collection<String> suggestions) {
+		return generate(String::toString, (s, t) -> StringTooltip.none(s), suggestions);
+	}
+
+	/**
+	 * Constructs a collection of {@link StringTooltip} objects from an array of suggestions, and a function which generates
+	 * a string tooltip for each suggestion
 	 *
 	 * @param tooltipGenerator function which returns a string tooltip for the suggestion
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link StringTooltip} objects from the provided suggestions, with the generated string tooltips
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestions, with the generated string
+	 * 	tooltips
 	 */
-	public static StringTooltip[] generateStrings(Function<String, String> tooltipGenerator, String... suggestions) {
+	public static Collection<StringTooltip> generateStrings(Function<String, String> tooltipGenerator, String... suggestions) {
 		return generate(tooltipGenerator, StringTooltip::ofString, suggestions);
 	}
 
 	/**
-	 * Constructs an array of {@link StringTooltip} objects from an array of suggestions,
-	 * and a function which generates a formatted tooltip for each suggestion
+	 * Constructs a collection of {@link StringTooltip} objects from a collection of suggestions, and a function which generates
+	 * a string tooltip for each suggestion
+	 *
+	 * @param tooltipGenerator function which returns a string tooltip for the suggestion
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestions, with the generated string
+	 * 	tooltips
+	 */
+	public static Collection<StringTooltip> generateStrings(Function<String, String> tooltipGenerator, Collection<String> suggestions) {
+		return generate(tooltipGenerator, StringTooltip::ofString, suggestions);
+	}
+
+	/**
+	 * Constructs a collection of {@link StringTooltip} objects from an array of suggestions, and a function which generates
+	 * a formatted tooltip for each suggestion
 	 *
 	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link StringTooltip} objects from the provided suggestions, with the generated formatted tooltips
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
 	 */
-	public static StringTooltip[] generateMessages(Function<String, Message> tooltipGenerator, String... suggestions) {
+	public static Collection<StringTooltip> generateMessages(Function<String, Message> tooltipGenerator, String... suggestions) {
 		return generate(tooltipGenerator, StringTooltip::ofMessage, suggestions);
 	}
 
 	/**
-	 * Constructs an array of {@link StringTooltip} objects from an array of suggestions,
-	 * and a function which generates a formatted tooltip for each suggestion
+	 * Constructs a collection of {@link StringTooltip} objects from a collection of suggestions, and a function which generates
+	 * a formatted tooltip for each suggestion
 	 *
-	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion,
-	 * as an array of bungee text components
-	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link StringTooltip} objects from the provided suggestions,
-	 * with the generated formatted tooltips
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
 	 */
-	public static StringTooltip[] generateBaseComponents(Function<String, BaseComponent[]> tooltipGenerator, String... suggestions) {
+	public static Collection<StringTooltip> generateMessages(Function<String, Message> tooltipGenerator, Collection<String> suggestions) {
+		return generate(tooltipGenerator, StringTooltip::ofMessage, suggestions);
+	}
+
+	/**
+	 * Constructs a collection of {@link StringTooltip} objects from an array of suggestions, and a function which generates
+	 * a formatted tooltip for each suggestion
+	 *
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an array of {@link BaseComponent}s
+	 * @param suggestions array of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
+	 */
+	public static Collection<StringTooltip> generateBaseComponents(Function<String, BaseComponent[]> tooltipGenerator, String... suggestions) {
 		return generate(tooltipGenerator, StringTooltip::ofBaseComponents, suggestions);
 	}
 
 	/**
-	 * Constructs an array of {@link StringTooltip} objects from an array of suggestions,
-	 * and a function which generates a formatted tooltip for each suggestion
+	 * Constructs a collection of {@link StringTooltip} objects from a collection of suggestions, and a function which generates
+	 * a formatted tooltip for each suggestion
 	 *
-	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion,
-	 * as an array of adventure text components
-	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link StringTooltip} objects from the provided suggestions,
-	 * with the generated formatted tooltips
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an array of {@link BaseComponent}s
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
 	 */
-	public static StringTooltip[] generateAdventureComponents(Function<String, Component> tooltipGenerator, String... suggestions) {
+	public static Collection<StringTooltip> generateBaseComponents(Function<String, BaseComponent[]> tooltipGenerator, Collection<String> suggestions) {
+		return generate(tooltipGenerator, StringTooltip::ofBaseComponents, suggestions);
+	}
+
+	/**
+	 * Constructs a collection of {@link StringTooltip} objects from an array of suggestions, and a function which generates
+	 * a tooltip formatted as an adventure {@link Component} for each suggestion
+	 *
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
+	 * @param suggestions array of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
+	 */
+	public static Collection<StringTooltip> generateAdventureComponents(Function<String, Component> tooltipGenerator, String... suggestions) {
+		return generate(tooltipGenerator, StringTooltip::ofAdventureComponent, suggestions);
+	}
+
+	/**
+	 * Constructs a collection of {@link StringTooltip} objects from a collection of suggestions, and a function which generates
+	 * a tooltip formatted as an adventure {@link Component} for each suggestion
+	 *
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
+	 */
+	public static Collection<StringTooltip> generateAdventureComponents(Function<String, Component> tooltipGenerator, Collection<String> suggestions) {
 		return generate(tooltipGenerator, StringTooltip::ofAdventureComponent, suggestions);
 	}
 
@@ -181,15 +256,37 @@ public class StringTooltip implements IStringTooltip {
 	 * @param tooltipGenerator tooltip generation function
 	 * @param tooltipWrapper function which wraps suggestion and tooltip into a {@link StringTooltip} object
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link StringTooltip} objects from the provided suggestion, wrapped using the above functions
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestion, wrapped using the above functions
 	 */
-	private static <T> StringTooltip[] generate(Function<String, T> tooltipGenerator, BiFunction<String, T, StringTooltip> tooltipWrapper, String... suggestions) {
-		StringTooltip[] tooltips = new StringTooltip[suggestions.length];
-		for(int i = 0; i < suggestions.length; i++) {
-			String suggestion = suggestions[i];
-			tooltips[i] = tooltipWrapper.apply(suggestion, tooltipGenerator.apply(suggestion));
-		}
-		return tooltips;
+	private static <T> Collection<StringTooltip> generate(Function<String, T> tooltipGenerator, BiFunction<String, T, StringTooltip> tooltipWrapper, String... suggestions) {
+		return generate(tooltipGenerator, tooltipWrapper, Arrays.stream(suggestions));
+	}
+
+	/**
+	 * Internal base method for the other generation types
+	 *
+	 * @param <T> the type of the tooltip
+	 * @param tooltipGenerator tooltip generation function
+	 * @param tooltipWrapper function which wraps suggestion and tooltip into a {@link StringTooltip} object
+	 * @param suggestions collection of suggestions to provide to the user
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestion, wrapped using the above functions
+	 */
+	private static <T> Collection<StringTooltip> generate(Function<String, T> tooltipGenerator, BiFunction<String, T, StringTooltip> tooltipWrapper, Collection<String> suggestions) {
+		return generate(tooltipGenerator, tooltipWrapper, suggestions.stream());
+	}
+
+	/**
+	 * Internal base method for the other generation types
+	 *
+	 * @param <T> the type of the tooltip
+	 * @param tooltipGenerator tooltip generation function
+	 * @param tooltipWrapper function which wraps suggestion and tooltip into a {@link StringTooltip} object
+	 * @param suggestions stream of suggestions to provide to the user
+	 * @return a collection of {@link StringTooltip} objects from the provided suggestion, wrapped using the above functions
+	 */
+	private static <T> Collection<StringTooltip> generate(Function<String, T> tooltipGenerator, BiFunction<String, T, StringTooltip> tooltipWrapper, Stream<String> suggestions) {
+		Function<String, StringTooltip> builder = suggestion -> tooltipWrapper.apply(suggestion, tooltipGenerator.apply(suggestion));
+		return suggestions.map(builder).toList();
 	}
 
 	private StringTooltip(String suggestion, Message tooltip) {

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/Tooltip.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/Tooltip.java
@@ -22,8 +22,8 @@ package dev.jorel.commandapi;
 
 import com.mojang.brigadier.LiteralMessage;
 import com.mojang.brigadier.Message;
-import net.kyori.adventure.platform.bukkit.BukkitComponentSerializer;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
 
@@ -298,7 +298,7 @@ public class Tooltip<S> {
 	 * @return native minecraft message object which can be used natively by brigadier.
 	 */
 	public static Message messageFromAdventureComponent(Component component) {
-		return CommandAPIHandler.getInstance().getNMS().generateMessageFromJson(BukkitComponentSerializer.gson().serialize(component));
+		return CommandAPIHandler.getInstance().getNMS().generateMessageFromJson(GsonComponentSerializer.gson().serialize(component));
 	}
 
 }

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/Tooltip.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/Tooltip.java
@@ -27,8 +27,11 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * This class represents a suggestion for an argument with a hover tooltip text
@@ -76,7 +79,7 @@ public class Tooltip<S> {
 	 *
 	 * @deprecated Please use {@link Tooltip#ofString(Object, String)} instead
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public static <S> Tooltip<S> of(S object, String tooltip) {
 		return ofString(object, tooltip);
 	}
@@ -145,91 +148,197 @@ public class Tooltip<S> {
 	}
 
 	/**
-	 * Constructs an array of {@link Tooltip<S>} objects from an array of suggestions, and no tooltips
+	 * Constructs a collection of {@link Tooltip<S>} objects from an array of suggestions, and no tooltips
 	 *
 	 * @param <S> the object that the argument suggestions use
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link Tooltip<S>} objects from the suggestions, with no tooltips
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the suggestions, with no tooltips
 	 */
 	@SafeVarargs
-	public static <S> Tooltip<S>[] none(S... suggestions) {
+	public static <S> Collection<Tooltip<S>> none(S... suggestions) {
 		return generate(S::toString, (s, t) -> Tooltip.none(s), suggestions);
 	}
 
 	/**
-	 * Constructs an array of {@link Tooltip<S>} objects from an array of suggestions,
-	 * and a function which generates a string tooltip for each suggestion
+	 * Constructs a collection of {@link Tooltip<S>} objects from a collection of suggestions, and no tooltips
+	 *
+	 * @param <S> the object that the argument suggestions use
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the suggestions, with no tooltips
+	 */
+	public static <S> Collection<Tooltip<S>> none(Collection<S> suggestions) {
+		return generate(S::toString, (s, t) -> Tooltip.none(s), suggestions);
+
+	}
+
+	/**
+	 * Constructs a collection of {@link Tooltip<S>} objects from an array of suggestions, and a function which generates a
+	 * string tooltip for each suggestion
 	 *
 	 * @param <S> the object that the argument suggestions use
 	 * @param tooltipGenerator function which returns a string tooltip for the suggestion
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link Tooltip<S>} objects from the provided suggestions, with the generated string tooltips
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestions, with the generated string tooltips
 	 */
 	@SafeVarargs
-	public static <S> Tooltip<S>[] generateStrings(Function<S, String> tooltipGenerator, S... suggestions) {
+	public static <S> Collection<Tooltip<S>> generateStrings(Function<S, String> tooltipGenerator, S... suggestions) {
 		return generate(tooltipGenerator, Tooltip::ofString, suggestions);
 	}
 
 	/**
-	 * Constructs an array of {@link Tooltip<S>} objects from an array of suggestions,
-	 * and a function which generates a formatted tooltip for each suggestion
+	 * Constructs a collection of {@link Tooltip<S>} objects from a collection of suggestions, and a function which generates a
+	 * string tooltip for each suggestion
+	 *
+	 * @param <S> the object that the argument suggestions use
+	 * @param tooltipGenerator function which returns a string tooltip for the suggestion
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestions, with the generated string tooltips
+	 */
+	public static <S> Collection<Tooltip<S>> generateStrings(Function<S, String> tooltipGenerator, Collection<S> suggestions) {
+		return generate(tooltipGenerator, Tooltip::ofString, suggestions);
+	}
+
+	/**
+	 * Constructs a collection of {@link Tooltip<S>} objects from an array of suggestions, and a function which generates a
+	 * formatted tooltip for each suggestion
 	 *
 	 * @param <S> the object that the argument suggestions use
 	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link Tooltip<S>} objects from the provided suggestions, with the generated formatted tooltips
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
 	 */
 	@SafeVarargs
-	public static <S> Tooltip<S>[] generateMessages(Function<S, Message> tooltipGenerator, S... suggestions) {
+	public static <S> Collection<Tooltip<S>> generateMessages(Function<S, Message> tooltipGenerator, S... suggestions) {
 		return generate(tooltipGenerator, Tooltip::ofMessage, suggestions);
 	}
 
 	/**
-	 * Constructs an array of {@link Tooltip<S>} objects from an array of suggestions,
-	 * and a function which generates a formatted tooltip for each suggestion
+	 * Constructs a collection of {@link Tooltip<S>} objects from an collection of suggestions, and a function which generates a
+	 * formatted tooltip for each suggestion
 	 *
 	 * @param <S> the object that the argument suggestions use
 	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
+	 */
+	public static <S> Collection<Tooltip<S>> generateMessages(Function<S, Message> tooltipGenerator, Collection<S> suggestions) {
+		return generate(tooltipGenerator, Tooltip::ofMessage, suggestions);
+	}
+
+	/**
+	 * Constructs a collection of {@link Tooltip<S>} objects from an array of suggestions, and a function which generates a
+	 * tooltip formatted as an array of {@link BaseComponent}s for each suggestion
+	 *
+	 * @param <S> the object that the argument suggestions use
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an array of {@link BaseComponent}s
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link Tooltip<S>} objects from the provided suggestions, with the generated formatted tooltips
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
 	 */
 	@SafeVarargs
-	public static <S> Tooltip<S>[] generateBaseComponents(Function<S, BaseComponent[]> tooltipGenerator, S... suggestions) {
+	public static <S> Collection<Tooltip<S>> generateBaseComponents(Function<S, BaseComponent[]> tooltipGenerator, S... suggestions) {
 		return generate(tooltipGenerator, Tooltip::ofBaseComponents, suggestions);
 	}
 
 	/**
-	 * Constructs an array of {@link Tooltip<S>} objects from an array of suggestions,
-	 * and a function which generates a formatted tooltip for each suggestion
+	 * Constructs a collection of {@link Tooltip<S>} objects from a collection of suggestions, and a function which generates a
+	 * tooltip formatted as an array of {@link BaseComponent}s for each suggestion
 	 *
 	 * @param <S> the object that the argument suggestions use
-	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an array of {@link BaseComponent}s
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
+	 */
+	public static <S> Collection<Tooltip<S>> generateBaseComponents(Function<S, BaseComponent[]> tooltipGenerator, Collection<S> suggestions) {
+		return generate(tooltipGenerator, Tooltip::ofBaseComponents, suggestions);
+	}
+
+	/**
+	 * Constructs a collection of {@link Tooltip<S>} objects from an array of suggestions, and a function which generates a
+	 * tooltip formatted as an adventure {@link Component} for each suggestion
+	 *
+	 * @param <S> the object that the argument suggestions use
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link Tooltip<S>} objects from the provided suggestions, with the generated formatted tooltips
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
 	 */
 	@SafeVarargs
-	public static <S> Tooltip<S>[] generateAdvenureComponents(Function<S, Component> tooltipGenerator, S... suggestions) {
+	public static <S> Collection<Tooltip<S>> generateAdvenureComponents(Function<S, Component> tooltipGenerator, S... suggestions) {
 		return generate(tooltipGenerator, Tooltip::ofAdventureComponent, suggestions);
 	}
 
 	/**
-	 * Internal base method for the other generation types
+	 * Constructs a collection of {@link Tooltip<S>} objects from a collection of suggestions, and a function which generates a
+	 * tooltip formatted as an adventure {@link Component} for each suggestion
+	 *
+	 * @param <S> the object that the argument suggestions use
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
+	 */
+	public static <S> Collection<Tooltip<S>> generateAdvenureComponents(Function<S, Component> tooltipGenerator, Collection<S> suggestions) {
+		return generate(tooltipGenerator, Tooltip::ofAdventureComponent, suggestions);
+	}
+
+	/**
+	 * Internal base method for the other generation types, for processing arrays
 	 *
 	 * @param <S> the object that the argument suggestions use
 	 * @param <T> the type of the tooltip
 	 * @param tooltipGenerator tooltip generation function
 	 * @param tooltipWrapper function which wraps suggestion and tooltip into a {@link Tooltip<S>} object
 	 * @param suggestions array of suggestions to provide to the user
-	 * @return an array of {@link Tooltip<S>} objects from the provided suggestion, wrapped using the above functions
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestion, wrapped using the above functions
 	 */
 	@SafeVarargs
-	private static <S, T> Tooltip<S>[] generate(Function<S, T> tooltipGenerator, BiFunction<S, T, Tooltip<S>> tooltipWrapper, S... suggestions) {
-		Tooltip<?>[] tooltips = new Tooltip<?>[suggestions.length];
-		for(int i = 0; i < suggestions.length; i++) {
-			S suggestion = suggestions[i];
-			tooltips[i] = tooltipWrapper.apply(suggestion, tooltipGenerator.apply(suggestion));
-		}
-		return (Tooltip<S>[]) tooltips;
+	private static <S, T> Collection<Tooltip<S>> generate(Function<S, T> tooltipGenerator, BiFunction<S, T, Tooltip<S>> tooltipWrapper, S... suggestions) {
+		return generate(tooltipGenerator, tooltipWrapper, Arrays.stream(suggestions));
+	}
+
+	/**
+	 * Internal base method for the other generation types, for processing collections
+	 *
+	 * @param <S> the object that the argument suggestions use
+	 * @param <T> the type of the tooltip
+	 * @param tooltipGenerator tooltip generation function
+	 * @param tooltipWrapper function which wraps suggestion and tooltip into a {@link Tooltip<S>} object
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestion, wrapped using the above functions
+	 */
+	private static <S, T> Collection<Tooltip<S>> generate(Function<S, T> tooltipGenerator, BiFunction<S, T, Tooltip<S>> tooltipWrapper, Collection<S> suggestions) {
+		return generate(tooltipGenerator, tooltipWrapper, suggestions.stream());
+	}
+
+	/**
+	 * Internal base method for the other generation types, for processing streams
+	 *
+	 * @param <S> the object that the argument suggestions use
+	 * @param <T> the type of the tooltip
+	 * @param tooltipGenerator tooltip generation function
+	 * @param tooltipWrapper function which wraps suggestion and tooltip into a {@link Tooltip<S>} object
+	 * @param suggestions stream of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link Tooltip<S>} objects from the provided suggestion, wrapped using the above functions
+	 */
+	private static <S, T> Collection<Tooltip<S>> generate(Function<S, T> tooltipGenerator, BiFunction<S, T, Tooltip<S>> tooltipWrapper, Stream<S> suggestions) {
+		return suggestions.map(suggestion -> tooltipWrapper.apply(suggestion,tooltipGenerator.apply(suggestion))).toList();
 	}
 
 	/**

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ArgumentSuggestions.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/ArgumentSuggestions.java
@@ -1,12 +1,12 @@
 package dev.jorel.commandapi.arguments;
 
-import com.mojang.brigadier.LiteralMessage;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import dev.jorel.commandapi.IStringTooltip;
 import dev.jorel.commandapi.SuggestionInfo;
 
+import java.util.Collection;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -43,71 +43,172 @@ public interface ArgumentSuggestions {
 
 	/**
 	 * Suggest hardcoded strings
+	 *
 	 * @param suggestions array of hardcoded strings
+	 *
 	 * @return an {@link ArgumentSuggestions} object suggesting hardcoded strings
 	 */
 	static ArgumentSuggestions strings(String... suggestions) {
-		return (info, builder) -> future(toSuggestions(builder, suggestions));
+		return (info, builder) -> future(suggestionsFromStrings(builder, suggestions));
 	}
 
 	/**
-	 * Suggest strings as the result of a function
-	 * @param suggestions function providing the strings
+	 * Suggest hardcoded strings
+	 *
+	 * @param suggestions collection of hardcoded strings
+	 *
+	 * @return an {@link ArgumentSuggestions} object suggesting hardcoded strings
+	 */
+	static ArgumentSuggestions strings(Collection<String> suggestions) {
+		return (info, builder) -> future(suggestionsFromStrings(builder, suggestions));
+	}
+
+	/**
+	 * Suggest an array of strings as the result of a function
+	 *
+	 * @param suggestions function providing the strings as an array
+	 *
 	 * @return an {@link ArgumentSuggestions} object suggesting the result of the function
 	 */
 	static ArgumentSuggestions strings(Function<SuggestionInfo, String[]> suggestions) {
-		return (info, builder) -> future(toSuggestions(builder, suggestions.apply(info)));
+		return (info, builder) -> future(suggestionsFromStrings(builder, suggestions.apply(info)));
 	}
 
 	/**
-	 * Suggest strings asynchronously
-	 * @param suggestions function providing the strings asynchronously
+	 * Suggest a collection of strings as the result of a function
+	 *
+	 * @param suggestions function providing the strings as a collection
+	 *
+	 * @return an {@link ArgumentSuggestions} object suggesting the result of the function
+	 */
+	static ArgumentSuggestions stringCollection(Function<SuggestionInfo, Collection<String>> suggestions) {
+		return (info, builder) -> future(suggestionsFromStrings(builder, suggestions.apply(info)));
+	}
+
+	/**
+	 * Suggest an array of strings asynchronously
+	 *
+	 * @param suggestions function providing the array of strings asynchronously
+	 *
 	 * @return an {@link ArgumentSuggestions} object suggesting the result of the asynchronous function
 	 */
 	static ArgumentSuggestions stringsAsync(Function<SuggestionInfo, CompletableFuture<String[]>> suggestions) {
 		return (info, builder) -> suggestions
 			.apply(info)
-			.thenApply(strings -> toSuggestions(builder, strings));
+			.thenApply(strings -> suggestionsFromStrings(builder, strings));
+	}
+
+	/**
+	 * Suggest a collection of strings asynchronously
+	 *
+	 * @param suggestions function providing the collection of strings asynchronously
+	 *
+	 * @return an {@link ArgumentSuggestions} object suggesting the result of the asynchronous function
+	 */
+	static ArgumentSuggestions stringCollectionAsync(Function<SuggestionInfo, CompletableFuture<Collection<String>>> suggestions) {
+		return (info, builder) -> suggestions
+			.apply(info)
+			.thenApply(strings -> suggestionsFromStrings(builder, strings));
 	}
 
 	/**
 	 * Suggest hardcoded strings with tooltips
-	 * @param suggestions array of hardcoded strings with tooltips
+	 *
+	 * @param suggestions collection of hardcoded strings with tooltips
+	 *
 	 * @return an {@link ArgumentSuggestions} object suggesting the hardcoded strings with tooltips
 	 */
 	static ArgumentSuggestions stringsWithTooltips(IStringTooltip... suggestions) {
-		return (info, builder) -> future(toSuggestions(builder, suggestions));
+		return (info, builder) -> future(suggestionsFromTooltips(builder, suggestions));
 	}
 
 	/**
-	 * Suggest strings with tooltips as the result of a function
-	 * @param suggestions function providing the strings with tooltips
+	 * Suggest hardcoded strings with tooltips
+	 *
+	 * @param suggestions collection of hardcoded strings with tooltips
+	 *
+	 * @return an {@link ArgumentSuggestions} object suggesting the hardcoded strings with tooltips
+	 */
+	static ArgumentSuggestions stringsWithTooltips(Collection<IStringTooltip> suggestions) {
+		return (info, builder) -> future(suggestionsFromTooltips(builder, suggestions));
+	}
+
+	/**
+	 * Suggest an array of strings with tooltips as the result of a function
+	 *
+	 * @param suggestions function providing the array of strings with tooltips
+	 *
 	 * @return an {@link ArgumentSuggestions} object suggesting the result of the function
 	 */
 	static ArgumentSuggestions stringsWithTooltips(Function<SuggestionInfo, IStringTooltip[]> suggestions) {
-		return (info, builder) -> future(toSuggestions(builder, suggestions.apply(info)));
+		return (info, builder) -> future(suggestionsFromTooltips(builder, suggestions.apply(info)));
 	}
 
 	/**
-	 * Suggest strings with tooltips asynchronously
-	 * @param suggestions function providing the strings with tooltips asynchronously
+	 * Suggest a collection of strings with tooltips as the result of a function
+	 *
+	 * @param suggestions function providing the collection of strings with tooltips
+	 *
+	 * @return an {@link ArgumentSuggestions} object suggesting the result of the function
+	 */
+	static ArgumentSuggestions stringsWithTooltipsCollection(Function<SuggestionInfo, Collection<IStringTooltip>> suggestions) {
+		return (info, builder) -> future(suggestionsFromTooltips(builder, suggestions.apply(info)));
+	}
+
+	/**
+	 * Suggest an array of strings with tooltips asynchronously
+	 *
+	 * @param suggestions function providing the array of strings with tooltips asynchronously
+	 *
 	 * @return an {@link ArgumentSuggestions} object suggesting the result of the asynchronous function
 	 */
 	static ArgumentSuggestions stringsWithTooltipsAsync(Function<SuggestionInfo, CompletableFuture<IStringTooltip[]>> suggestions) {
 		return (info, builder) -> suggestions
 			.apply(info)
-			.thenApply(stringsWithTooltips -> toSuggestions(builder, stringsWithTooltips));
+			.thenApply(stringsWithTooltips -> suggestionsFromTooltips(builder, stringsWithTooltips));
+	}
+
+	/**
+	 * Suggest a collection of strings with tooltips asynchronously
+	 *
+	 * @param suggestions function providing the collection of strings with tooltips asynchronously
+	 *
+	 * @return an {@link ArgumentSuggestions} object suggesting the result of the asynchronous function
+	 */
+	static ArgumentSuggestions stringsWithTooltipsCollectionAsync(Function<SuggestionInfo, CompletableFuture<Collection<IStringTooltip>>> suggestions) {
+		return (info, builder) -> suggestions
+			.apply(info)
+			.thenApply(stringsWithTooltips -> suggestionsFromTooltips(builder, stringsWithTooltips));
 	}
 
 	/**
 	 * Convert an array of strings into a brigadier {@link Suggestions} object
+	 *
 	 * @param builder brigadier {@link SuggestionsBuilder} object for building the suggestions
 	 * @param suggestions array of strings
+	 *
 	 * @return a brigadier {@link Suggestions} object suggesting the array of strings
 	 */
-	private static Suggestions toSuggestions(SuggestionsBuilder builder, String... suggestions) {
+	private static Suggestions suggestionsFromStrings(SuggestionsBuilder builder, String... suggestions) {
 		for(String suggestion : suggestions) {
-			if(suggestion.toLowerCase(Locale.ROOT).startsWith(builder.getRemaining().toLowerCase(Locale.ROOT))) {
+			if(shouldSuggest(builder, suggestion)) {
+				builder.suggest(suggestion);
+			}
+		}
+		return builder.build();
+	}
+
+	/**
+	 * Convert a collection of strings into a brigadier {@link Suggestions} object
+	 *
+	 * @param builder brigadier {@link SuggestionsBuilder} object for building the suggestions
+	 * @param suggestions collection of strings
+	 *
+	 * @return a brigadier {@link Suggestions} object suggesting the collection of strings
+	 */
+	private static Suggestions suggestionsFromStrings(SuggestionsBuilder builder, Collection<String> suggestions) {
+		for(String suggestion : suggestions) {
+			if(shouldSuggest(builder, suggestion)) {
 				builder.suggest(suggestion);
 			}
 		}
@@ -116,29 +217,64 @@ public interface ArgumentSuggestions {
 
 	/**
 	 * Convert an array of strings with tooltips into a brigadier {@link Suggestions} object
+	 *
 	 * @param builder brigadier {@link SuggestionsBuilder} object for building the suggestions
 	 * @param suggestions array of strings with tooltips
+	 *
 	 * @return a brigadier {@link Suggestions} object suggesting the array of strings with tooltips
 	 */
-	private static Suggestions toSuggestions(SuggestionsBuilder builder, IStringTooltip... suggestions) {
+	private static Suggestions suggestionsFromTooltips(SuggestionsBuilder builder, IStringTooltip... suggestions) {
 		for(IStringTooltip suggestion : suggestions) {
-			if(!suggestion.getSuggestion().toLowerCase(Locale.ROOT).startsWith(builder.getRemaining().toLowerCase(Locale.ROOT))) {
-				continue;
-			}
-
-			if(suggestion.getTooltip() == null) {
-				builder.suggest(suggestion.getSuggestion());
-			} else {
-				builder.suggest(suggestion.getSuggestion(), suggestion.getTooltip());
-			}
+			processSuggestion(builder, suggestion);
 		}
 		return builder.build();
 	}
 
 	/**
+	 * Convert a collection of strings with tooltips into a brigadier {@link Suggestions} object
+	 *
+	 * @param builder brigadier {@link SuggestionsBuilder} object for building the suggestions
+	 * @param suggestions collection of strings with tooltips
+	 *
+	 * @return a brigadier {@link Suggestions} object suggesting the collection of strings with tooltips
+	 */
+	private static Suggestions suggestionsFromTooltips(SuggestionsBuilder builder, Collection<IStringTooltip> suggestions) {
+		for(IStringTooltip suggestion : suggestions) {
+			processSuggestion(builder, suggestion);
+		}
+		return builder.build();
+	}
+
+	private static void processSuggestion(SuggestionsBuilder builder, IStringTooltip suggestion) {
+		if(!shouldSuggest(builder, suggestion.getSuggestion())) {
+			return;
+		}
+
+		if(suggestion.getTooltip() == null) {
+			builder.suggest(suggestion.getSuggestion());
+		} else {
+			builder.suggest(suggestion.getSuggestion(), suggestion.getTooltip());
+		}
+	}
+
+	/**
+	 * Returns whether the typed text should be suggested by the current suggestion
+	 *
+	 * @param builder SuggestionsBuilder object
+	 * @param suggestion string suggestion
+	 *
+	 * @return true if the current input is a prefix of the suggestion, false otherwise
+	 */
+	private static boolean shouldSuggest(SuggestionsBuilder builder, String suggestion) {
+		return suggestion.toLowerCase(Locale.ROOT).startsWith(builder.getRemaining().toLowerCase(Locale.ROOT));
+	}
+
+	/**
 	 * Wrap a value in a {@link CompletableFuture}
+	 *
 	 * @param value the value
 	 * @param <T> type of the value
+	 *
 	 * @return a {@link CompletableFuture} resolving instantly in the value
 	 */
 	private static <T> CompletableFuture<T> future(T value) {

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/SafeSuggestions.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/SafeSuggestions.java
@@ -4,8 +4,11 @@ import dev.jorel.commandapi.IStringTooltip;
 import dev.jorel.commandapi.SuggestionInfo;
 import dev.jorel.commandapi.Tooltip;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * This class represents safe suggestions. These are parameterized suggestions which can be converted
@@ -19,14 +22,18 @@ public interface SafeSuggestions<S> {
 	/**
 	 * Convert this {@link SafeSuggestions} object into an {@link ArgumentSuggestions} by mapping the values with a string
 	 * mapping function.
+	 *
 	 * @param mapper a function which maps an instance of {@link S} to a string.
+	 *
 	 * @return an {@link ArgumentSuggestions} object resulting from this mapping.
 	 */
 	ArgumentSuggestions toSuggestions(Function<S, String> mapper);
 
 	/**
 	 * Create an empty SafeSuggestions object.
+	 *
 	 * @param <T> type parameter of the SafeSuggestions object
+	 *
 	 * @return a SafeSuggestions object resulting in empty suggestions
 	 */
 	static <T> SafeSuggestions<T> empty() {
@@ -34,9 +41,11 @@ public interface SafeSuggestions<S> {
 	}
 
 	/**
-	 * Hardcode values to suggest
-	 * @param suggestions hardcoded values
+	 * Hardcode an array of values to suggest
+	 *
+	 * @param suggestions array of hardcoded values
 	 * @param <T> type of the values
+	 *
 	 * @return a SafeSuggestions object suggesting the hardcoded suggestions
 	 */
 	@SafeVarargs
@@ -45,31 +54,75 @@ public interface SafeSuggestions<S> {
 	}
 
 	/**
-	 * Suggest values as the result of a function
-	 * @param suggestions function providing the values
+	 * Hardcode a collection of values to suggest
+	 *
+	 * @param suggestions collection of hardcoded values
 	 * @param <T> type of the values
-	 * @return a SafeSuggestion object suggesting the result of the function
+	 *
+	 * @return a SafeSuggestions object suggesting the hardcoded suggestions
 	 */
-	static <T> SafeSuggestions<T> suggest(Function<SuggestionInfo, T[]> suggestions) {
-		return (mapper) -> ArgumentSuggestions.strings(info -> toStrings(mapper, suggestions.apply(info)));
+	static <T> SafeSuggestions<T> suggest(Collection<T> suggestions) {
+		return (mapper) -> ArgumentSuggestions.strings(toStrings(mapper, suggestions));
 	}
 
 	/**
-	 * Suggest values provided asynchronously
-	 * @param suggestions function providing the values asynchronously
+	 * Suggest an array of values as the result of a function
+	 *
+	 * @param suggestions function providing the array of values
 	 * @param <T> type of the values
+	 *
+	 * @return a SafeSuggestion object suggesting the result of the function
+	 */
+	static <T> SafeSuggestions<T> suggest(Function<SuggestionInfo, T[]> suggestions) {
+		return (mapper) -> ArgumentSuggestions.stringCollection(info -> toStrings(mapper, suggestions.apply(info)));
+	}
+
+	/**
+	 * Suggest a collection of values as the result of a function
+	 *
+	 * @param suggestions function providing the collection of values
+	 * @param <T> type of the values
+	 *
+	 * @return a SafeSuggestion object suggesting the result of the function
+	 */
+	static <T> SafeSuggestions<T> suggestCollection(Function<SuggestionInfo, Collection<T>> suggestions) {
+		return (mapper) -> ArgumentSuggestions.stringCollection(info -> toStrings(mapper, suggestions.apply(info)));
+	}
+
+	/**
+	 * Suggest an array of values provided asynchronously
+	 *
+	 * @param suggestions function providing the array of values asynchronously
+	 * @param <T> type of the values
+	 *
 	 * @return a SafeSuggestion object suggestion the result of the asynchronous function
 	 */
 	static <T> SafeSuggestions<T> suggestAsync(Function<SuggestionInfo, CompletableFuture<T[]>> suggestions) {
-		return (mapper) -> ArgumentSuggestions.stringsAsync(info -> suggestions
+		return (mapper) -> ArgumentSuggestions.stringCollectionAsync(info -> suggestions
 			.apply(info)
 			.thenApply(items -> toStrings(mapper, items)));
 	}
 
 	/**
-	 * Suggest hardcoded values with tooltips
-	 * @param suggestions hardcoded values with their tooltips
+	 * Suggest a collection of values provided asynchronously
+	 *
+	 * @param suggestions function providing the collection of values asynchronously
 	 * @param <T> type of the values
+	 *
+	 * @return a SafeSuggestion object suggestion the result of the asynchronous function
+	 */
+	static <T> SafeSuggestions<T> suggestCollectionAsync(Function<SuggestionInfo, CompletableFuture<Collection<T>>> suggestions) {
+		return (mapper) -> ArgumentSuggestions.stringCollectionAsync(info -> suggestions
+			.apply(info)
+			.thenApply(items -> toStrings(mapper, items)));
+	}
+
+	/**
+	 * Suggest an array of hardcoded values with tooltips
+	 *
+	 * @param suggestions array of hardcoded values with their tooltips
+	 * @param <T> type of the values
+	 *
 	 * @return a SafeSuggestion object suggesting the hardcoded values
 	 */
 	@SafeVarargs
@@ -78,61 +131,143 @@ public interface SafeSuggestions<S> {
 	}
 
 	/**
-	 * Suggest values with tooltips as the result of a function
-	 * @param suggestions function providing the values with tooltips
+	 * Suggest a collection of hardcoded values with tooltips
+	 *
+	 * @param suggestions collection of hardcoded values with their tooltips
 	 * @param <T> type of the values
+	 *
+	 * @return a SafeSuggestion object suggesting the hardcoded values
+	 */
+	static <T> SafeSuggestions<T> tooltips(Collection<Tooltip<T>> suggestions) {
+		return (mapper) -> ArgumentSuggestions.stringsWithTooltips(toStringsWithTooltips(mapper, suggestions));
+	}
+
+	/**
+	 * Suggest an array of values with tooltips as the result of a function
+	 *
+	 * @param suggestions function providing the array of values with tooltips
+	 * @param <T> type of the values
+	 *
 	 * @return a SafeSuggestion object suggesting the result of the function
 	 */
 	static <T> SafeSuggestions<T> tooltips(Function<SuggestionInfo, Tooltip<T>[]> suggestions) {
-		return (mapper) -> ArgumentSuggestions.stringsWithTooltips(info -> toStringsWithTooltips(mapper,
+		return (mapper) -> ArgumentSuggestions.stringsWithTooltipsCollection(info -> toStringsWithTooltips(mapper,
 			suggestions.apply(info)
 		));
 	}
 
 	/**
-	 * Suggest values with tooltips asynchronously
-	 * @param suggestions function providing the values with tooltips
+	 * Suggest a collection of values with tooltips as the result of a function
+	 *
+	 * @param suggestions function providing the collection of values with tooltips
 	 * @param <T> type of the values
+	 *
+	 * @return a SafeSuggestion object suggesting the result of the function
+	 */
+	static <T> SafeSuggestions<T> tooltipCollection(Function<SuggestionInfo, Collection<Tooltip<T>>> suggestions) {
+		return (mapper) -> ArgumentSuggestions.stringsWithTooltipsCollection(info -> toStringsWithTooltips(mapper,
+			suggestions.apply(info)
+		));
+	}
+
+	/**
+	 * Suggest an array of values with tooltips asynchronously
+	 *
+	 * @param suggestions function providing the collection of values with tooltips asynchronously
+	 * @param <T> type of the values
+	 *
 	 * @return a SafeSuggestion suggesting the result of the asynchronous function
 	 */
 	static <T> SafeSuggestions<T> tooltipsAsync(Function<SuggestionInfo, CompletableFuture<Tooltip<T>[]>> suggestions) {
-		return (mapper) -> ArgumentSuggestions.stringsWithTooltipsAsync(info -> suggestions
+		return (mapper) -> ArgumentSuggestions.stringsWithTooltipsCollectionAsync(info -> suggestions
 			.apply(info)
 			.thenApply(items -> toStringsWithTooltips(mapper, items)));
 	}
 
 	/**
-	 * Convert an array of values into an array of strings using the mapping function
-	 * @param mapper the mapping function
-	 * @param suggestions the array of values
+	 * Suggest a collection of values with tooltips asynchronously
+	 *
+	 * @param suggestions function providing the array of values with tooltips asynchronously
 	 * @param <T> type of the values
-	 * @return array of strings representing the array of values under the mapping function
+	 *
+	 * @return a SafeSuggestion suggesting the result of the asynchronous function
 	 */
-	@SafeVarargs
-	private static <T> String[] toStrings(Function<T, String> mapper, T... suggestions) {
-		String[] strings = new String[suggestions.length];
-		for(int i = 0; i < suggestions.length; i++) {
-			strings[i] = mapper.apply(suggestions[i]);
-		}
-		return strings;
+	static <T> SafeSuggestions<T> tooltipCollectionAsync(Function<SuggestionInfo, CompletableFuture<Collection<Tooltip<T>>>> suggestions) {
+		return (mapper) -> ArgumentSuggestions.stringsWithTooltipsCollectionAsync(info -> suggestions
+			.apply(info)
+			.thenApply(items -> toStringsWithTooltips(mapper, items)));
 	}
 
 	/**
+	 * Convert an array of values into a collection of strings using the mapping function
+	 *
+	 * @param mapper the mapping function
+	 * @param suggestions the array of values
+	 * @param <T> type of the values
+	 *
+	 * @return array of strings representing the array of values under the mapping function
+	 */
+	@SafeVarargs
+	private static <T> Collection<String> toStrings(Function<T, String> mapper, T... suggestions) {
+		return Arrays.stream(suggestions).map(mapper).toList();
+	}
+
+	/**
+	 * Convert a collection of values into a collection of strings using the mapping function
+	 *
+	 * @param mapper the mapping function
+	 * @param suggestions the collection of values
+	 * @param <T> type of the values
+	 *
+	 * @return collection of strings representing the collection of values under the mapping function
+	 */
+	private static <T> Collection<String> toStrings(Function<T, String> mapper, Collection<T> suggestions) {
+		return suggestions.stream().map(mapper).toList();
+	}
+
+
+	/**
 	 * Convert an array of values with tooltips into an array of strings with tooltips using the mapping function
+	 *
 	 * @param mapper the mapping function
 	 * @param suggestions the array of values with tooltips
 	 * @param <T> type of the values
+	 *
 	 * @return array of strings with tooltips representing the array of values with tooltips under the mapping function
 	 */
 	@SafeVarargs
-	private static <T> IStringTooltip[] toStringsWithTooltips(Function<T, String> mapper, Tooltip<T>... suggestions) {
-		IStringTooltip[] stringsWithTooltips = new IStringTooltip[suggestions.length];
-		for(int i = 0; i < suggestions.length; i++) {
-			stringsWithTooltips[i] = Tooltip
-				.build(mapper)
-				.apply(suggestions[i]);
-		}
-		return stringsWithTooltips;
+	private static <T> Collection<IStringTooltip> toStringsWithTooltips(Function<T, String> mapper, Tooltip<T>... suggestions) {
+		return toStringsWithTooltips(mapper, Arrays.stream(suggestions));
+	}
+
+	/**
+	 * Convert a collection of values with tooltips into a collection of strings with tooltips using the mapping function
+	 *
+	 * @param mapper the mapping function
+	 * @param suggestions the collection of values with tooltips
+	 * @param <T> type of the values
+	 *
+	 * @return collection of strings with tooltips representing the collection of values with tooltips under the mapping function
+	 */
+
+	private static <T> Collection<IStringTooltip> toStringsWithTooltips(Function<T, String> mapper, Collection<Tooltip<T>> suggestions) {
+		return toStringsWithTooltips(mapper, suggestions.stream());
+	}
+
+	/**
+	 * Convert a stream of values with tooltips into a collection of strings with tooltips using the mapping function
+	 *
+	 * @param mapper the mapping function
+	 * @param suggestions the stream of values with tooltips
+	 * @param <T> type of the values
+	 *
+	 * @return collection of strings with tooltips representing the collection of values with tooltips under the mapping function
+	 */
+
+	private static <T> Collection<IStringTooltip> toStringsWithTooltips(Function<T, String> mapper, Stream<Tooltip<T>> suggestions) {
+		//Note the ::apply is required to allow the return type to be IStringTooltip instead of StringTooltip
+		Function<Tooltip<T>, IStringTooltip> builder = Tooltip.build(mapper)::apply;
+		return suggestions.map(builder).toList();
 	}
 
 }


### PR DESCRIPTION
This PR simply adds overrides for passing collections for arguments and tooltips as well as using arrays.
The aim of this is to avoid conversion into arrays when generating suggestions or tooltips. This can be particularly irritating when generics get involved, so instead collections avoid this problem.

For example in `ArgumentSuggestions`
```java
	 /**
	 * Suggest hardcoded strings
	 *
	 * @param suggestions array of hardcoded strings
	 *
	 * @return an {@link ArgumentSuggestions} object suggesting hardcoded strings
	 */
	static ArgumentSuggestions strings(String... suggestions) {
		return (info, builder) -> future(suggestionsFromStrings(builder, suggestions));
	}
```

gets an additional overload

```java 
	/**
	 * Suggest hardcoded strings
	 *
	 * @param suggestions collection of hardcoded strings
	 *
	 * @return an {@link ArgumentSuggestions} object suggesting hardcoded strings
	 */
	static ArgumentSuggestions strings(Collection<String> suggestions) {
		return (info, builder) -> future(suggestionsFromStrings(builder, suggestions));
	}
```
This is repeated for all methods in `ArgumentSuggestions`, `SafeSuggestions`, `Tooltip`, and `StringTooltip` that use array arguments or varargs.

Unfortunately due to Generic erasure with the `Function` type, it was not possible to keep all overloads with the same name

```java
	/**
	 * Suggest an array of strings as the result of a function
	 *
	 * @param suggestions function providing the strings as an array
	 *
	 * @return an {@link ArgumentSuggestions} object suggesting the result of the function
	 */
	static ArgumentSuggestions strings(Function<SuggestionInfo, String[]> suggestions) {
		return (info, builder) -> future(suggestionsFromStrings(builder, suggestions.apply(info)));
	}

	/**
	 * Suggest a collection of strings as the result of a function
	 *
	 * @param suggestions function providing the strings as a collection
	 *
	 * @return an {@link ArgumentSuggestions} object suggesting the result of the function
	 */
	static ArgumentSuggestions stringCollection(Function<SuggestionInfo, Collection<String>> suggestions) {
		return (info, builder) -> future(suggestionsFromStrings(builder, suggestions.apply(info)));
	}
```

In my opinion it's not worth deprecating the original method in favour of something like `stringArray(Function<SuggestionInfo, String[]>)` but this is of course possible if required.

The return type of methods in `Tooltip` and `StringTooltip` have all been migrated to use Collection instead of array to avoid problems with generic array creation and unchecked casts.

It doesn't entirely sit right with me just how many methods now exist in these classes, but this is due to the inflexibility of Java's type system. This is also why I created `ArgumentSuggestions` and `SafeSuggestions` classes, to store these factory methods without needing to modify the `Argument` implementation.