### PR TITLE
add missing .register() methods in Example.kt

### DIFF
--- a/commandapi-core/src/test/kotlin/Examples.kt
+++ b/commandapi-core/src/test/kotlin/Examples.kt
@@ -942,6 +942,7 @@ CommandAPICommand("mycommand")
 	.executes(CommandExecutor { _, args ->
 		val text = args[0] as String
 	})
+	.register()
 
 CommandAPICommand("mycommand")
 	.withArguments(LiteralArgument.literal("hello"))
@@ -949,6 +950,7 @@ CommandAPICommand("mycommand")
 	.executes(CommandExecutor { _, args ->
 		val text = args[0] as String
 	})
+	.register()
 /* ANCHOR_END: literalarguments3 */
 }
 


### PR DESCRIPTION
I sadly forgot to add the `.register()` methods to the examples in `Examples.kt` which is why I am doing this now.
I will do better next time, I promise.