### PR TITLE
Make the CommandAPI complain less about command registered in the plugin.yml

### DIFF
--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -387,7 +387,7 @@ public abstract class CommandAPIBukkit<Source> extends CommandAPIPlatform<Argume
 				"Plugin command /%s is registered by Bukkit (%s). Did you forget to remove this from your plugin.yml file?"
 					.formatted(commandName, pluginName));
 		} else {
-			CommandAPI.logInfo(
+			CommandAPI.logNormal(
 				"Plugin command /%s is registered by Bukkit. You may have to use /minecraft:%s to execute your command."
 					.formatted(commandName, commandName));
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -378,10 +378,14 @@ public abstract class CommandAPIBukkit<Source> extends CommandAPIPlatform<Argume
 		// Warn if the command we're registering already exists in this plugin's
 		// plugin.yml file
 		final PluginCommand pluginCommand = Bukkit.getPluginCommand(commandName);
-		if (pluginCommand != null) {
+		if (pluginCommand == null) {
+			return;
+		}
+		String pluginName = pluginCommand.getPlugin().getName();
+		if (config.getPlugin().getName().equals(pluginName)) {
 			CommandAPI.logWarning(
 				"Plugin command /%s is registered by Bukkit (%s). Did you forget to remove this from your plugin.yml file?"
-					.formatted(commandName, pluginCommand.getPlugin().getName()));
+					.formatted(commandName, pluginName));
 		}
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -386,6 +386,10 @@ public abstract class CommandAPIBukkit<Source> extends CommandAPIPlatform<Argume
 			CommandAPI.logWarning(
 				"Plugin command /%s is registered by Bukkit (%s). Did you forget to remove this from your plugin.yml file?"
 					.formatted(commandName, pluginName));
+		} else {
+			CommandAPI.logInfo(
+				"Plugin command /%s is registered by Bukkit. You may have to use /minecraft:%s to execute your command."
+					.formatted(commandName, commandName));
 		}
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -388,8 +388,8 @@ public abstract class CommandAPIBukkit<Source> extends CommandAPIPlatform<Argume
 					.formatted(commandName, pluginName));
 		} else {
 			CommandAPI.logNormal(
-				"Plugin command /%s is registered by Bukkit. You may have to use /minecraft:%s to execute your command."
-					.formatted(commandName, commandName));
+				"Plugin command /%s is registered by Bukkit (%s). You may have to use /minecraft:%s to execute your command."
+					.formatted(commandName, pluginName, commandName));
 		}
 	}
 


### PR DESCRIPTION
The title is not great, I know and it can be misunderstood!

### I once experienced this while using the CommandAPI:
In my plugin, I register a command permission. LuckPerms also registers a command permission.
The CommandAPI does this:
`[01:15:12 WARN]: [CommandAPI] Plugin command /permission is registered by Bukkit (LuckPerms). Did you forget to remove this from your plugin.yml file?`

### Here is what the PR does:
This PR makes it so that the CommandAPI doesn't complain about plugin commands registered in a `plugin.yml` if the `plugin.yml` doesn't belong to the plugin calling the CommandAPI.