### PR TITLE
Allow required arguments after optional arguments

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandAPICommand.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandAPICommand.java
@@ -304,32 +304,14 @@ public abstract class AbstractCommandAPICommand<Impl extends AbstractCommandAPIC
 	private List<Argument[]> getArgumentsToRegister(Argument[] argumentsArray) {
 		List<Argument[]> argumentsToRegister = new ArrayList<>();
 
-		// Check optional argument constraints
-		// They can only be at the end, no required argument can follow an optional argument
-		int firstOptionalArgumentIndex = -1;
-		for (int i = 0, optionalArgumentIndex = -1; i < argumentsArray.length; i++) {
-			if (argumentsArray[i].isOptional()) {
-				if (firstOptionalArgumentIndex == -1) {
-					firstOptionalArgumentIndex = i;
-				}
-				optionalArgumentIndex = i;
-			} else if (optionalArgumentIndex != -1) {
-				// Argument is not optional
-				throw new OptionalArgumentException(meta.commandName);
-			}
+		// Create a List of arrays that hold arguments to register split based on where optional arguments are
+		List<Argument> currentCommand = new ArrayList<>(argumentsArray.length);
+		for(Argument argument : argumentsArray) {
+			if(argument.isOptional()) argumentsToRegister.add((Argument[]) currentCommand.toArray(new AbstractArgument[0]));
+			currentCommand.add(argument);
 		}
-
-		// Create a List of arrays that hold arguments to register optional arguments
-		// if optional arguments have been found
-		if (firstOptionalArgumentIndex != -1) {
-			for (int i = 0; i <= argumentsArray.length; i++) {
-				if (i >= firstOptionalArgumentIndex) {
-					Argument[] arguments = (Argument[]) new AbstractArgument[i];
-					System.arraycopy(argumentsArray, 0, arguments, 0, i);
-					argumentsToRegister.add(arguments);
-				}
-			}
-		}
+		// All arguments are also valid and not added by above loop
+		argumentsToRegister.add(argumentsArray);
 		return argumentsToRegister;
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -26,7 +26,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import dev.jorel.commandapi.arguments.IntegerArgument;
+import dev.jorel.commandapi.arguments.PlayerArgument;
+import dev.jorel.commandapi.arguments.StringArgument;
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.InvalidPluginException;
 import org.bukkit.plugin.Plugin;
@@ -125,5 +129,32 @@ public class CommandAPIMain extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		CommandAPI.onEnable();
+
+		// TODO: Example command, remove before merging
+		new CommandAPICommand("rate")
+			.withArguments(
+				new StringArgument("topic").setOptional(true),
+				new IntegerArgument("rating", 0, 10),
+				new PlayerArgument("target").setOptional(true)
+			)
+			.executes(info -> {
+				String topic = (String) info.args().get("topic");
+				if(topic == null) {
+					// Honestly not sure how to justify topic being optional here,
+					// causing there to be a required argument after an optional one,
+					// but I'm sure an example exists, right?
+					info.sender().sendMessage("You didn't give a rating");
+					return;
+				}
+
+				// We know this is not null because rating is required if topic is given
+				int rating = (int) info.args().get("rating");
+
+				// The target player is optional, so give it a default here
+				CommandSender target = (CommandSender) info.args().getOrDefault("target", info.sender());
+
+				target.sendMessage("Your " + topic + " was rated: " + rating + "/10");
+			})
+			.register();
 	}
 }


### PR DESCRIPTION
This PR is me implementing what I was trying to explain [here](https://discord.com/channels/745416925924032523/745419648970784821/1060603371159044157) in discord so I can explain it better.

Currently, if you put a required argument after an optional argument, you get an `OptionalArgumentException`. However, I think this example command makes a good case for changing that:
```java
new CommandAPICommand("rate")
	.withArguments(
		new StringArgument("topic").setOptional(true),
		new IntegerArgument("rating", 0, 10),
		new PlayerArgument("target").setOptional(true)
	)
	.executes(info -> {
		String topic = (String) info.args().get("topic");
		if(topic == null) {
			// Honestly not sure how to justify topic being optional here,
			// causing there to be a required argument after an optional one,
			// but I'm sure an example exists, right?
			info.sender().sendMessage("You didn't give a rating");
			return;
		}

		// We know this is not null because rating is required if topic is given
		int rating = (int) info.args().get("rating");

		// The target player is optional, so give it a default here
		CommandSender target = (CommandSender) info.args().getOrDefault("target", info.sender());

		target.sendMessage("Your " + topic + " was rated: " + rating + "/10");
	})
	.register();
```

This command can be executed in the following ways:
```
/rate
/rate <topic> <rating>
/rate <topic> <rating> <target>
```

Putting the required `<rating>` argument after the optional `<topic>` argument indicates that if a `topic` is given, a `rating` is required.

To make this work was actually very simple, just a small change to the old system. `AbstractCommandAPICommand#getArgumentsToRegister` now looks like this:
```java
private List<Argument[]> getArgumentsToRegister(Argument[] argumentsArray) {
	List<Argument[]> argumentsToRegister = new ArrayList<>();

	// Create a List of arrays that hold arguments to register split based on where optional arguments are
	List<Argument> currentCommand = new ArrayList<>(argumentsArray.length);
	for(Argument argument : argumentsArray) {
		if(argument.isOptional()) argumentsToRegister.add((Argument[]) currentCommand.toArray(new AbstractArgument[0]));
		currentCommand.add(argument);
	}
	// All arguments are also valid and not added by above loop
	argumentsToRegister.add(argumentsArray);
	return argumentsToRegister;
}
```

### TODO before merge:
- Get the idea approved
- Remove `OptionalArgumentException`? (I don't think it is used anymore)
- [ ] Update documentation
- [ ] Update `commandapi-bukkit-plugin-test`
- [ ] Remove the example command from CommandAPIMain