### PR TITLE
Registering commands during server runtime (Bukkit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ This is the current roadmap for the CommandAPI (as of 11th May 2023):
                     <li>Fixed the CommandAPI disabling datapacks on Paper 1.20.1 #40+ because it thought it was running on a Folia server</li>
                     <li>https://github.com/JorelAli/CommandAPI/pull/459 Added the ability to access raw arguments in the command executor</li>
                     <li>https://github.com/JorelAli/CommandAPI/issues/469 Adds <code>AdventureChatColorArgument</code></li>
+					<li>https://github.com/JorelAli/CommandAPI/pull/417 Added the ability for commands to be registered and unregistered while the server is running</li>
                 </ul>
             </td>
         </tr>

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandAPICommand.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandAPICommand.java
@@ -272,10 +272,6 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 
 	@Override
 	public void register() {
-		if (!CommandAPI.canRegister()) {
-			CommandAPI.logWarning("Command /" + meta.commandName + " is being registered after the server had loaded. Undefined behavior ahead!");
-		}
-
 		@SuppressWarnings("unchecked")
 		Argument[] argumentsArray = (Argument[]) (arguments == null ? new AbstractArgument[0] : arguments.toArray(AbstractArgument[]::new));
 

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
@@ -266,10 +266,6 @@ public class CommandAPI {
 	 *                across all plugins as well as minecraft, bukkit and spigot
 	 */
 	public static void unregister(String command, boolean force) {
-		if (!canRegister) {
-			getLogger().warning("Unexpected unregistering of /" + command
-				+ ", as server is loaded! Unregistering anyway, but this can lead to unstable results!");
-		}
 		CommandAPIHandler.getInstance().getPlatform().unregister(command, force);
 	}
 

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
@@ -262,11 +262,12 @@ public class CommandAPI {
 	 * Unregisters a command, by force (removes all instances of that command)
 	 *
 	 * @param command the name of the command to unregister
-	 * @param force   if true, attempt to unregister all instances of the command
-	 *                across all plugins as well as minecraft, bukkit and spigot
+	 * @param unregisterNamespaces whether the unregistration system should attempt to remove versions of the
+	 *                                command that start with a namespace. Eg. `minecraft:command`, `bukkit:command`,
+	 *                                or `plugin:command`
 	 */
-	public static void unregister(String command, boolean force) {
-		CommandAPIHandler.getInstance().getPlatform().unregister(command, force);
+	public static void unregister(String command, boolean unregisterNamespaces) {
+		CommandAPIHandler.getInstance().getPlatform().unregister(command, unregisterNamespaces);
 	}
 
 	/**

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
@@ -259,12 +259,13 @@ public class CommandAPI {
 	}
 
 	/**
-	 * Unregisters a command, by force (removes all instances of that command)
+	 * Unregisters a command
 	 *
 	 * @param command the name of the command to unregister
 	 * @param unregisterNamespaces whether the unregistration system should attempt to remove versions of the
-	 *                                command that start with a namespace. Eg. `minecraft:command`, `bukkit:command`,
-	 *                                or `plugin:command`
+	 *                                command that start with a namespace. E.g. `minecraft:command`, `bukkit:command`,
+	 *                                or `plugin:command`. If true, these namespaced versions of a command are also
+	 *                                unregistered.
 	 */
 	public static void unregister(String command, boolean unregisterNamespaces) {
 		CommandAPIHandler.getInstance().getPlatform().unregister(command, unregisterNamespaces);

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIHandler.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIHandler.java
@@ -605,16 +605,18 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 		for (int i = 0, size = registeredCommands.size(); i < size && !hasRegisteredCommand; i++) {
 			hasRegisteredCommand |= registeredCommands.get(i).commandName().equals(commandName);
 		}
+
 		if (hasRegisteredCommand && hasCommandConflict(commandName, args, humanReadableCommandArgSyntax)) {
 			return;
-		} else {
-			List<String> argumentsString = new ArrayList<>();
-			for (Argument arg : args) {
-				argumentsString.add(arg.getNodeName() + ":" + arg.getClass().getSimpleName());
-			}
-			registeredCommands.add(new RegisteredCommand(commandName, argumentsString, shortDescription,
-					fullDescription, usageDescription, aliases, permission));
 		}
+
+		List<String> argumentsString = new ArrayList<>();
+		for (Argument arg : args) {
+			argumentsString.add(arg.getNodeName() + ":" + arg.getClass().getSimpleName());
+		}
+		RegisteredCommand registeredCommandInformation = new RegisteredCommand(commandName, argumentsString, shortDescription,
+			fullDescription, usageDescription, aliases, permission);
+		registeredCommands.add(registeredCommandInformation);
 
 		// Handle previewable arguments
 		handlePreviewableArguments(commandName, args, aliases);
@@ -681,7 +683,7 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 		// partial) command registration. Generate the dispatcher file!
 		writeDispatcherToFile();
 
-		platform.postCommandRegistration(resultantNode, aliasNodes);
+		platform.postCommandRegistration(registeredCommandInformation, resultantNode, aliasNodes);
 	}
 	
 	/**

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIHandler.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIHandler.java
@@ -720,7 +720,7 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 		return true;
 	}
 	
-	private void writeDispatcherToFile() {
+	public void writeDispatcherToFile() {
 		File file = CommandAPI.getConfiguration().getDispatcherFile();
 		if (file != null) {
 			try {

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIPlatform.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIPlatform.java
@@ -98,10 +98,11 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 	/**
 	 * Stuff to run after a command has been generated.
 	 *
-	 * @param resultantNode the node that was registered
-	 * @param aliasNodes    any alias nodes that were also registered as a part of this registration process
+	 * @param registeredCommand A {@link RegisteredCommand} instance that holds the CommandAPI information for the command
+	 * @param resultantNode     The node that was registered
+	 * @param aliasNodes        Any alias nodes that were also registered as a part of this registration process
 	 */
-	public abstract void postCommandRegistration(LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes);
+	public abstract void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes);
 
 	/**
 	 * Registers a Brigadier command node and returns the built node.

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIPlatform.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIPlatform.java
@@ -114,11 +114,11 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 	 * Unregisters a command from the CommandGraph so it can't be run anymore.
 	 *
 	 * @param commandName the name of the command to unregister
-	 * @param force       whether the unregistration system should attempt to remove
-	 *                    all instances of the command, regardless of whether they
-	 *                    have been registered by Minecraft, Bukkit or Spigot etc.
+	 * @param unregisterNamespaces whether the unregistration system should attempt to remove versions of the
+	 *                                command that start with a namespace. Eg. `minecraft:command`, `bukkit:command`,
+	 *                                or `plugin:command`
 	 */
-	public abstract void unregister(String commandName, boolean force);
+	public abstract void unregister(String commandName, boolean unregisterNamespaces);
 
 	/**
 	 * @return The Brigadier CommandDispatcher tree being used by the platform's server

--- a/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
+++ b/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
@@ -67,6 +67,7 @@ import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Scoreboard;
@@ -1393,19 +1394,118 @@ new CommandAPICommand("broadcastmsg")
     })
     .register();
 /* ANCHOR_END: commandRegistration1 */
+}
 
-/* ANCHOR: commandRegistration2 */
-// Unregister the gamemode command from the server (by force)
-CommandAPI.unregister("gamemode", true);
+class CommandUnregistration {
+class UnregistrationBukkit extends JavaPlugin {
+/* ANCHOR: commandUnregistrationBukkit */
+@Override
+public void onLoad() {
+    CommandAPIBukkit.unregister("version", true, true);
+}
+/* ANCHOR_END: commandUnregistrationBukkit */
+}
 
-// Register our new /gamemode, with survival, creative, adventure and spectator
-new CommandAPICommand("gamemode")
-    .withArguments(new MultiLiteralArgument("gamemodes", "survival", "creative", "adventure", "spectator"))
-    .executes((sender, args) -> {
-        // Implementation of our /gamemode command
-    })
-    .register();
-/* ANCHOR_END: commandRegistration2 */
+class UnregistrationVanilla extends JavaPlugin {
+/* ANCHOR: commandUnregistrationVanilla */
+@Override
+public void onEnable() {
+    CommandAPI.unregister("gamemode");
+}
+/* ANCHOR_END: commandUnregistrationVanilla */
+}
+
+class UnregistrationReplaceVanilla extends JavaPlugin {
+/* ANCHOR: commandUnregistrationReplaceVanilla */
+@Override
+public void onEnable() {
+    CommandAPI.unregister("gamemode");
+
+    // Register our new /gamemode, with survival, creative, adventure and spectator
+    new CommandAPICommand("gamemode")
+        .withArguments(new MultiLiteralArgument("gamemodes", "survival", "creative", "adventure", "spectator"))
+        .executes((sender, args) -> {
+            // Implementation of our /gamemode command
+        })
+        .register();
+}
+/* ANCHOR_END: commandUnregistrationReplaceVanilla */
+}
+
+class UnregistrationPlugin extends JavaPlugin {
+/* ANCHOR: commandUnregistrationPlugin */
+@Override
+public void onEnable() {
+    CommandAPIBukkit.unregister("luckperms:luckperms", false, true);
+}
+/* ANCHOR_END: commandUnregistrationPlugin */
+}
+
+class UnregistrationCommandAPI extends JavaPlugin {
+/* ANCHOR: commandUnregistrationCommandAPI */
+@Override
+public void onEnable() {
+    CommandAPI.unregister("break");
+}
+/* ANCHOR_END: commandUnregistrationCommandAPI */
+}
+
+class UnregistrationBukkitHelp extends JavaPlugin {
+/* ANCHOR: commandUnregistrationBukkitHelp */
+@Override
+public void onEnable() {
+    new BukkitRunnable() {
+        @Override
+        public void run() {
+            CommandAPIBukkit.unregister("help", false, true);
+        }
+    }.runTaskLater(this, 0);
+}
+/* ANCHOR_END: commandUnregistrationBukkitHelp */
+}
+
+class UnregistrationOnlyVanillaNamespace extends JavaPlugin {
+/* ANCHOR: commandUnregistrationOnlyVanillaNamespace */
+@Override
+public void onEnable() {
+    new BukkitRunnable() {
+        @Override
+        public void run() {
+            CommandAPI.unregister("minecraft:gamemode");
+        }
+    }.runTaskLater(this, 0);
+}
+/* ANCHOR_END: commandUnregistrationOnlyVanillaNamespace */
+}
+
+class UnregistrationDealyedVanillaBad extends JavaPlugin {
+/* ANCHOR: commandUnregistrationDealyedVanillaBad */
+// NOT RECOMMENDED
+@Override
+public void onEnable() {
+    new BukkitRunnable() {
+        @Override
+        public void run() {
+            CommandAPI.unregister("gamemode");
+        }
+    }.runTaskLater(this, 0);
+}
+/* ANCHOR_END: commandUnregistrationDealyedVanillaBad */
+}
+
+class UnregistrationDealyedVanillaBetter extends JavaPlugin {
+/* ANCHOR: commandUnregistrationDealyedVanillaBetter */
+@Override
+public void onEnable() {
+    new BukkitRunnable() {
+        @Override
+        public void run() {
+            CommandAPI.unregister("gamemode", true);
+        }
+    }.runTaskLater(this, 0);
+}
+/* ANCHOR_END: commandUnregistrationDealyedVanillaBetter */
+}
 }
 
 class commandTrees extends JavaPlugin {

--- a/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
+++ b/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
@@ -1396,118 +1396,6 @@ new CommandAPICommand("broadcastmsg")
 /* ANCHOR_END: commandRegistration1 */
 }
 
-class CommandUnregistration {
-class UnregistrationBukkit extends JavaPlugin {
-/* ANCHOR: commandUnregistrationBukkit */
-@Override
-public void onLoad() {
-    CommandAPIBukkit.unregister("version", true, true);
-}
-/* ANCHOR_END: commandUnregistrationBukkit */
-}
-
-class UnregistrationVanilla extends JavaPlugin {
-/* ANCHOR: commandUnregistrationVanilla */
-@Override
-public void onEnable() {
-    CommandAPI.unregister("gamemode");
-}
-/* ANCHOR_END: commandUnregistrationVanilla */
-}
-
-class UnregistrationReplaceVanilla extends JavaPlugin {
-/* ANCHOR: commandUnregistrationReplaceVanilla */
-@Override
-public void onEnable() {
-    CommandAPI.unregister("gamemode");
-
-    // Register our new /gamemode, with survival, creative, adventure and spectator
-    new CommandAPICommand("gamemode")
-        .withArguments(new MultiLiteralArgument("gamemodes", "survival", "creative", "adventure", "spectator"))
-        .executes((sender, args) -> {
-            // Implementation of our /gamemode command
-        })
-        .register();
-}
-/* ANCHOR_END: commandUnregistrationReplaceVanilla */
-}
-
-class UnregistrationPlugin extends JavaPlugin {
-/* ANCHOR: commandUnregistrationPlugin */
-@Override
-public void onEnable() {
-    CommandAPIBukkit.unregister("luckperms:luckperms", false, true);
-}
-/* ANCHOR_END: commandUnregistrationPlugin */
-}
-
-class UnregistrationCommandAPI extends JavaPlugin {
-/* ANCHOR: commandUnregistrationCommandAPI */
-@Override
-public void onEnable() {
-    CommandAPI.unregister("break");
-}
-/* ANCHOR_END: commandUnregistrationCommandAPI */
-}
-
-class UnregistrationBukkitHelp extends JavaPlugin {
-/* ANCHOR: commandUnregistrationBukkitHelp */
-@Override
-public void onEnable() {
-    new BukkitRunnable() {
-        @Override
-        public void run() {
-            CommandAPIBukkit.unregister("help", false, true);
-        }
-    }.runTaskLater(this, 0);
-}
-/* ANCHOR_END: commandUnregistrationBukkitHelp */
-}
-
-class UnregistrationOnlyVanillaNamespace extends JavaPlugin {
-/* ANCHOR: commandUnregistrationOnlyVanillaNamespace */
-@Override
-public void onEnable() {
-    new BukkitRunnable() {
-        @Override
-        public void run() {
-            CommandAPI.unregister("minecraft:gamemode");
-        }
-    }.runTaskLater(this, 0);
-}
-/* ANCHOR_END: commandUnregistrationOnlyVanillaNamespace */
-}
-
-class UnregistrationDealyedVanillaBad extends JavaPlugin {
-/* ANCHOR: commandUnregistrationDealyedVanillaBad */
-// NOT RECOMMENDED
-@Override
-public void onEnable() {
-    new BukkitRunnable() {
-        @Override
-        public void run() {
-            CommandAPI.unregister("gamemode");
-        }
-    }.runTaskLater(this, 0);
-}
-/* ANCHOR_END: commandUnregistrationDealyedVanillaBad */
-}
-
-class UnregistrationDealyedVanillaBetter extends JavaPlugin {
-/* ANCHOR: commandUnregistrationDealyedVanillaBetter */
-@Override
-public void onEnable() {
-    new BukkitRunnable() {
-        @Override
-        public void run() {
-            CommandAPI.unregister("gamemode", true);
-        }
-    }.runTaskLater(this, 0);
-}
-/* ANCHOR_END: commandUnregistrationDealyedVanillaBetter */
-}
-}
-
 class commandTrees extends JavaPlugin {
 {
 /* ANCHOR: commandTrees1 */
@@ -1573,6 +1461,118 @@ public Sign getTargetSign(Player player) throws WrapperCommandSyntaxException {
     } else {
         throw CommandAPI.failWithString("You're not looking at a sign!");
     }
+}
+}
+
+class CommandUnregistration {
+class UnregistrationBukkit extends JavaPlugin {
+/* ANCHOR: commandUnregistration1 */
+@Override
+public void onLoad() {
+    CommandAPIBukkit.unregister("version", true, true);
+}
+/* ANCHOR_END: commandUnregistration1 */
+}
+
+class UnregistrationVanilla extends JavaPlugin {
+/* ANCHOR: commandUnregistration2 */
+@Override
+public void onEnable() {
+    CommandAPI.unregister("gamemode");
+}
+/* ANCHOR_END: commandUnregistration2 */
+}
+
+class UnregistrationReplaceVanilla extends JavaPlugin {
+/* ANCHOR: commandUnregistration3 */
+@Override
+public void onEnable() {
+    CommandAPI.unregister("gamemode");
+
+    // Register our new /gamemode, with survival, creative, adventure and spectator
+    new CommandAPICommand("gamemode")
+        .withArguments(new MultiLiteralArgument("gamemodes", "survival", "creative", "adventure", "spectator"))
+        .executes((sender, args) -> {
+            // Implementation of our /gamemode command
+        })
+        .register();
+}
+/* ANCHOR_END: commandUnregistration3 */
+}
+
+class UnregistrationPlugin extends JavaPlugin {
+/* ANCHOR: commandUnregistration4 */
+@Override
+public void onEnable() {
+    CommandAPIBukkit.unregister("luckperms:luckperms", false, true);
+}
+/* ANCHOR_END: commandUnregistration4 */
+}
+
+class UnregistrationCommandAPI extends JavaPlugin {
+/* ANCHOR: commandUnregistration5 */
+@Override
+public void onEnable() {
+    CommandAPI.unregister("break");
+}
+/* ANCHOR_END: commandUnregistration5 */
+}
+
+class UnregistrationBukkitHelp extends JavaPlugin {
+/* ANCHOR: commandUnregistration6 */
+@Override
+public void onEnable() {
+    new BukkitRunnable() {
+        @Override
+        public void run() {
+            CommandAPIBukkit.unregister("help", false, true);
+        }
+    }.runTaskLater(this, 0);
+}
+/* ANCHOR_END: commandUnregistration6 */
+}
+
+class UnregistrationOnlyVanillaNamespace extends JavaPlugin {
+/* ANCHOR: commandUnregistration7 */
+@Override
+public void onEnable() {
+    new BukkitRunnable() {
+        @Override
+        public void run() {
+            CommandAPI.unregister("minecraft:gamemode");
+        }
+    }.runTaskLater(this, 0);
+}
+/* ANCHOR_END: commandUnregistration7 */
+}
+
+class UnregistrationDelayedVanillaBad extends JavaPlugin {
+/* ANCHOR: commandUnregistration8 */
+// NOT RECOMMENDED
+@Override
+public void onEnable() {
+    new BukkitRunnable() {
+        @Override
+        public void run() {
+            CommandAPI.unregister("gamemode");
+        }
+    }.runTaskLater(this, 0);
+}
+/* ANCHOR_END: commandUnregistration8 */
+}
+
+class UnregistrationDelayedVanillaBetter extends JavaPlugin {
+/* ANCHOR: commandUnregistration9 */
+@Override
+public void onEnable() {
+    new BukkitRunnable() {
+        @Override
+        public void run() {
+            CommandAPI.unregister("gamemode", true);
+        }
+    }.runTaskLater(this, 0);
+}
+/* ANCHOR_END: commandUnregistration9 */
 }
 }
 

--- a/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
+++ b/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
@@ -43,6 +43,7 @@ import org.bukkit.metadata.FixedMetadataValue
 import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.potion.PotionEffect
 import org.bukkit.potion.PotionEffectType
+import org.bukkit.scheduler.BukkitRunnable
 import org.bukkit.scoreboard.DisplaySlot
 import org.bukkit.scoreboard.Objective
 import org.bukkit.scoreboard.Team
@@ -1309,19 +1310,105 @@ CommandAPICommand("broadcastmsg")
     })
     .register()
 /* ANCHOR_END: commandRegistration1 */
+}
 
-/* ANCHOR: commandRegistration2 */
-// Unregister the gamemode command from the server (by force)
-CommandAPI.unregister("gamemode", true)
+class CommandUnregistration {
+class UnregistrationBukkit : JavaPlugin() {
+/* ANCHOR: commandUnregistrationBukkit */
+override fun onLoad() {
+    CommandAPIBukkit.unregister("version", false, true)
+}
+/* ANCHOR_END: commandUnregistrationBukkit */
+}
 
-// Register our new /gamemode, with survival, creative, adventure and spectator
-CommandAPICommand("gamemode")
-    .withArguments(MultiLiteralArgument("gamemodes", "survival", "creative", "adventure", "spectator"))
-    .executes(CommandExecutor { sender, args ->
-        // Implementation of our /gamemode command
-    })
-    .register()
-/* ANCHOR_END: commandRegistration2 */
+class UnregistrationVanilla : JavaPlugin() {
+/* ANCHOR: commandUnregistrationVanilla */
+override fun onEnable() {
+    CommandAPI.unregister("gamemode")
+}
+/* ANCHOR_END: commandUnregistrationVanilla */
+}
+
+class UnregistrationReplaceVanilla : JavaPlugin() {
+/* ANCHOR: commandUnregistrationReplaceVanilla */
+override fun onEnable() {
+    CommandAPI.unregister("gamemode");
+
+    // Register our new /gamemode, with survival, creative, adventure and spectator
+    CommandAPICommand("gamemode")
+        .withArguments(MultiLiteralArgument("gamemodes", "survival", "creative", "adventure", "spectator"))
+        .executes(CommandExecutor { sender, args ->
+            // Implementation of our /gamemode command
+        })
+        .register()
+}
+/* ANCHOR_END: commandUnregistrationReplaceVanilla */
+}
+
+class UnregistrationPlugin : JavaPlugin() {
+/* ANCHOR: commandUnregistrationPlugin */
+override fun onEnable() {
+    CommandAPIBukkit.unregister("luckperms:luckperms", false, true)
+}
+/* ANCHOR_END: commandUnregistrationPlugin */
+}
+
+class UnregistrationCommandAPI : JavaPlugin() {
+/* ANCHOR: commandUnregistrationCommandAPI */
+override fun onEnable() {
+    CommandAPI.unregister("break")
+}
+/* ANCHOR_END: commandUnregistrationCommandAPI */
+}
+
+class UnregistrationBukkitHelp : JavaPlugin() {
+/* ANCHOR: commandUnregistrationBukkitHelp */
+override fun onEnable() {
+    object : BukkitRunnable() {
+        override fun run() {
+            CommandAPIBukkit.unregister("help", false, true)
+        }
+    }.runTaskLater(this, 0)
+}
+/* ANCHOR_END: commandUnregistrationBukkitHelp */
+}
+
+class UnregistrationOnlyVanillaNamespace : JavaPlugin() {
+/* ANCHOR: commandUnregistrationOnlyVanillaNamespace */
+override fun onEnable() {
+    object : BukkitRunnable() {
+        override fun run() {
+            CommandAPI.unregister("minecraft:gamemode")
+        }
+    }.runTaskLater(this, 0)
+}
+/* ANCHOR_END: commandUnregistrationOnlyVanillaNamespace */
+}
+
+class UnregistrationDealyedVanillaBad : JavaPlugin() {
+/* ANCHOR: commandUnregistrationDealyedVanillaBad */
+// NOT RECOMMENDED
+override fun onEnable() {
+    object : BukkitRunnable() {
+        override fun run() {
+            CommandAPI.unregister("gamemode")
+        }
+    }.runTaskLater(this, 0)
+}
+/* ANCHOR_END: commandUnregistrationDealyedVanillaBad */
+}
+
+class UnregistrationDealyedVanillaBetter : JavaPlugin() {
+/* ANCHOR: commandUnregistrationDealyedVanillaBetter */
+override fun onEnable() {
+    object : BukkitRunnable() {
+        override fun run() {
+            CommandAPI.unregister("gamemode", true)
+        }
+    }.runTaskLater(this, 0)
+}
+/* ANCHOR_END: commandUnregistrationDealyedVanillaBetter */
+}
 }
 
 class commandTrees : JavaPlugin() {

--- a/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
+++ b/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
@@ -1312,105 +1312,6 @@ CommandAPICommand("broadcastmsg")
 /* ANCHOR_END: commandRegistration1 */
 }
 
-class CommandUnregistration {
-class UnregistrationBukkit : JavaPlugin() {
-/* ANCHOR: commandUnregistrationBukkit */
-override fun onLoad() {
-    CommandAPIBukkit.unregister("version", false, true)
-}
-/* ANCHOR_END: commandUnregistrationBukkit */
-}
-
-class UnregistrationVanilla : JavaPlugin() {
-/* ANCHOR: commandUnregistrationVanilla */
-override fun onEnable() {
-    CommandAPI.unregister("gamemode")
-}
-/* ANCHOR_END: commandUnregistrationVanilla */
-}
-
-class UnregistrationReplaceVanilla : JavaPlugin() {
-/* ANCHOR: commandUnregistrationReplaceVanilla */
-override fun onEnable() {
-    CommandAPI.unregister("gamemode");
-
-    // Register our new /gamemode, with survival, creative, adventure and spectator
-    CommandAPICommand("gamemode")
-        .withArguments(MultiLiteralArgument("gamemodes", "survival", "creative", "adventure", "spectator"))
-        .executes(CommandExecutor { sender, args ->
-            // Implementation of our /gamemode command
-        })
-        .register()
-}
-/* ANCHOR_END: commandUnregistrationReplaceVanilla */
-}
-
-class UnregistrationPlugin : JavaPlugin() {
-/* ANCHOR: commandUnregistrationPlugin */
-override fun onEnable() {
-    CommandAPIBukkit.unregister("luckperms:luckperms", false, true)
-}
-/* ANCHOR_END: commandUnregistrationPlugin */
-}
-
-class UnregistrationCommandAPI : JavaPlugin() {
-/* ANCHOR: commandUnregistrationCommandAPI */
-override fun onEnable() {
-    CommandAPI.unregister("break")
-}
-/* ANCHOR_END: commandUnregistrationCommandAPI */
-}
-
-class UnregistrationBukkitHelp : JavaPlugin() {
-/* ANCHOR: commandUnregistrationBukkitHelp */
-override fun onEnable() {
-    object : BukkitRunnable() {
-        override fun run() {
-            CommandAPIBukkit.unregister("help", false, true)
-        }
-    }.runTaskLater(this, 0)
-}
-/* ANCHOR_END: commandUnregistrationBukkitHelp */
-}
-
-class UnregistrationOnlyVanillaNamespace : JavaPlugin() {
-/* ANCHOR: commandUnregistrationOnlyVanillaNamespace */
-override fun onEnable() {
-    object : BukkitRunnable() {
-        override fun run() {
-            CommandAPI.unregister("minecraft:gamemode")
-        }
-    }.runTaskLater(this, 0)
-}
-/* ANCHOR_END: commandUnregistrationOnlyVanillaNamespace */
-}
-
-class UnregistrationDealyedVanillaBad : JavaPlugin() {
-/* ANCHOR: commandUnregistrationDealyedVanillaBad */
-// NOT RECOMMENDED
-override fun onEnable() {
-    object : BukkitRunnable() {
-        override fun run() {
-            CommandAPI.unregister("gamemode")
-        }
-    }.runTaskLater(this, 0)
-}
-/* ANCHOR_END: commandUnregistrationDealyedVanillaBad */
-}
-
-class UnregistrationDealyedVanillaBetter : JavaPlugin() {
-/* ANCHOR: commandUnregistrationDealyedVanillaBetter */
-override fun onEnable() {
-    object : BukkitRunnable() {
-        override fun run() {
-            CommandAPI.unregister("gamemode", true)
-        }
-    }.runTaskLater(this, 0)
-}
-/* ANCHOR_END: commandUnregistrationDealyedVanillaBetter */
-}
-}
-
 class commandTrees : JavaPlugin() {
 fun commandTrees1() {
 /* ANCHOR: commandTrees1 */
@@ -1477,6 +1378,105 @@ fun getTargetSign(player: Player): Sign {
     } else {
         throw CommandAPI.failWithString("You're not looking at a sign!")
     }
+}
+}
+
+class CommandUnregistration {
+class UnregistrationBukkit : JavaPlugin() {
+/* ANCHOR: commandUnregistration1 */
+override fun onLoad() {
+    CommandAPIBukkit.unregister("version", false, true)
+}
+/* ANCHOR_END: commandUnregistration1 */
+}
+
+class UnregistrationVanilla : JavaPlugin() {
+/* ANCHOR: commandUnregistration2 */
+override fun onEnable() {
+    CommandAPI.unregister("gamemode")
+}
+/* ANCHOR_END: commandUnregistration2 */
+}
+
+class UnregistrationReplaceVanilla : JavaPlugin() {
+/* ANCHOR: commandUnregistration3 */
+override fun onEnable() {
+    CommandAPI.unregister("gamemode");
+
+    // Register our new /gamemode, with survival, creative, adventure and spectator
+    CommandAPICommand("gamemode")
+        .withArguments(MultiLiteralArgument("gamemodes", "survival", "creative", "adventure", "spectator"))
+        .executes(CommandExecutor { sender, args ->
+            // Implementation of our /gamemode command
+        })
+        .register()
+}
+/* ANCHOR_END: commandUnregistration3 */
+}
+
+class UnregistrationPlugin : JavaPlugin() {
+/* ANCHOR: commandUnregistration4 */
+override fun onEnable() {
+    CommandAPIBukkit.unregister("luckperms:luckperms", false, true)
+}
+/* ANCHOR_END: commandUnregistration4 */
+}
+
+class UnregistrationCommandAPI : JavaPlugin() {
+/* ANCHOR: commandUnregistration5 */
+override fun onEnable() {
+    CommandAPI.unregister("break")
+}
+/* ANCHOR_END: commandUnregistration5 */
+}
+
+class UnregistrationBukkitHelp : JavaPlugin() {
+/* ANCHOR: commandUnregistration6 */
+override fun onEnable() {
+    object : BukkitRunnable() {
+        override fun run() {
+            CommandAPIBukkit.unregister("help", false, true)
+        }
+    }.runTaskLater(this, 0)
+}
+/* ANCHOR_END: commandUnregistration6 */
+}
+
+class UnregistrationOnlyVanillaNamespace : JavaPlugin() {
+/* ANCHOR: commandUnregistration7 */
+override fun onEnable() {
+    object : BukkitRunnable() {
+        override fun run() {
+            CommandAPI.unregister("minecraft:gamemode")
+        }
+    }.runTaskLater(this, 0)
+}
+/* ANCHOR_END: commandUnregistration7 */
+}
+
+class UnregistrationDelayedVanillaBad : JavaPlugin() {
+/* ANCHOR: commandUnregistration8 */
+// NOT RECOMMENDED
+override fun onEnable() {
+    object : BukkitRunnable() {
+        override fun run() {
+            CommandAPI.unregister("gamemode")
+        }
+    }.runTaskLater(this, 0)
+}
+/* ANCHOR_END: commandUnregistration8 */
+}
+
+class UnregistrationDelayedVanillaBetter : JavaPlugin() {
+/* ANCHOR: commandUnregistration9 */
+override fun onEnable() {
+    object : BukkitRunnable() {
+        override fun run() {
+            CommandAPI.unregister("gamemode", true)
+        }
+    }.runTaskLater(this, 0)
+}
+/* ANCHOR_END: commandUnregistration9 */
 }
 }
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -463,7 +463,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 			// Sending command dispatcher packets usually happens when Players join the server
 			for(Player p: Bukkit.getOnlinePlayers()) {
-				resendPackets(p);
+				p.updateCommands();
 			}
 		}
 	}
@@ -514,7 +514,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 				getHelpMap().remove("/" + commandName);
 
 				for (Player p : Bukkit.getOnlinePlayers()) {
-					resendPackets(p);
+					p.updateCommands();
 				}
 			}
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -468,16 +468,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 	@Override
 	public LiteralCommandNode<Source> registerCommandNode(LiteralArgumentBuilder<Source> node) {
-		CommandAPI.logInfo("Registering command with brigadier");
-		LiteralCommandNode<Source> builtNode = getBrigadierDispatcher().register(node);
-		if(!CommandAPI.canRegister()) {
-			CommandAPI.logInfo("Forcing node into bukkit command map");
-			// Bukkit is done with normal command stuff, so we have to modify their CommandMap ourselves
-			Command command = wrapToVanillaCommandWrapper(builtNode);
-			paper.getCommandMap().register("minecraft", command);
-		}
-
-		return builtNode;
+		return getBrigadierDispatcher().register(node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -494,20 +494,28 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 	@Override
 	public void unregister(String commandName, boolean unregisterNamespaces) {
-		unregister(commandName, unregisterNamespaces, false);
+		unregisterInternal(commandName, unregisterNamespaces, false);
 	}
 
-	// TODO: Should there be a static version of this method so developers don't have to call CommandAPIBukkit.get()?
 	/**
-	 * Unregisters a command from the CommandGraph so it can't be run anymore.
+	 * Unregisters a command from the CommandGraph, so it can't be run anymore. This Bukkit-specific unregister has an
+	 * additional parameter, {@code unregisterBukkit}, compared to {@link CommandAPI#unregister(String, boolean)}.
 	 *
 	 * @param commandName          the name of the command to unregister
 	 * @param unregisterNamespaces whether the unregistration system should attempt to remove versions of the
-	 *                                command that start with a namespace. Eg. `minecraft:command`, `bukkit:command`,
-	 *                                or `plugin:command`
-	 * @param unregisterBukkit     whether the unregistration system should unregister
+	 *                                command that start with a namespace. E.g. `minecraft:command`, `bukkit:command`,
+	 *                                or `plugin:command`. If true, these namespaced versions of a command are also
+	 *                                unregistered.
+	 * @param unregisterBukkit     whether the unregistration system should unregister Vanilla or Bukkit commands. If true,
+	 *                             only Bukkit commands are unregistered, otherwise only Vanilla commands are unregistered.
+	 *                             For the purposes of this parameter, commands registered using the CommandAPI are Vanilla
+	 *                             commands, and commands registered by other plugin using Bukkit API are Bukkit commands.
 	 */
-	public void unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit) {
+	public static void unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit) {
+		CommandAPIBukkit.get().unregisterInternal(commandName, unregisterNamespaces, unregisterBukkit);
+	}
+
+	private void unregisterInternal(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit) {
 		CommandAPI.logInfo("Unregistering command /" + commandName);
 
 		if(!unregisterBukkit) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -518,6 +518,9 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 				}
 			}
 		}
+
+		// Update the dispatcher file
+		CommandAPIHandler.getInstance().writeDispatcherToFile();
 	}
 
 	private void removeCommandNamespace(Map<String, ?> map, String commandName) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -488,7 +488,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		if (!CommandAPI.canRegister() || force) {
 			// Bukkit is done with normal command stuff, so we have to modify their CommandMap ourselves
 			// If we're forcing, we'll also go here to make sure commands are really gone
-			Map<String, Command> knownCommands = getKnownCommands();
+			Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) paper.getCommandMap());
 			knownCommands.remove(commandName);
 			if (force) removeCommandNamespace(knownCommands, commandName);
 
@@ -529,10 +529,6 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 				map.remove(key);
 			}
 		}
-	}
-
-	private Map<String, Command> getKnownCommands() {
-		return commandMapKnownCommands.get((SimpleCommandMap) paper.getCommandMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -447,6 +447,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 			// Adding commands to the other (Why bukkit/spigot?!) dispatcher usually happens in `CraftServer#syncCommands`
 			root.addChild(resultantNode);
+			root.addChild(namespaceNode(resultantNode));
 
 			// Do the same for the aliases
 			for(LiteralCommandNode<Source> node: aliasNodes) {
@@ -456,6 +457,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 				command.setPermission(permNode);
 
 				root.addChild(node);
+				root.addChild(namespaceNode(node));
 			}
 
 			// Adding the command to the help map usually happens in `CommandAPIBukkit#onEnable`
@@ -466,6 +468,23 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 				p.updateCommands();
 			}
 		}
+	}
+
+	private LiteralCommandNode<Source> namespaceNode(LiteralCommandNode<Source> original) {
+		// Adapted from a section of `CraftServer#syncCommands`
+		LiteralCommandNode<Source> clone = new LiteralCommandNode<>(
+			"minecraft:" + original.getLiteral(),
+			original.getCommand(),
+			original.getRequirement(),
+			original.getRedirect(),
+			original.getRedirectModifier(),
+			original.isFork()
+		);
+
+		for (CommandNode<Source> child : original.getChildren()) {
+			clone.addChild(child);
+		}
+		return clone;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.ChatColor;
@@ -436,6 +437,14 @@ public interface NMS<CommandListenerWrapper> {
 	 * @return A VanillaCommandWrapper representing the given node
 	 */
 	Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node);
+
+	/**
+	 * Checks if a Brigadier command node is being handled by Bukkit's BukkitCommandWrapper
+	 *
+	 * @param node The CommandNode to check
+	 * @return true if the CommandNode is being handled by Bukkit's BukkitCommandWrapper
+	 */
+	boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node);
 
 	/**
 	 * Reloads the datapacks by using the updated the commandDispatcher tree

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
@@ -444,7 +444,7 @@ public interface NMS<CommandListenerWrapper> {
 
 	HelpTopic generateHelpTopic(String commandName, String shortDescription, String fullDescription, String permission);
 
-	void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd);
+	Map<String, HelpTopic> getHelpMap();
 
 	Message generateMessageFromJson(String json);
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -298,13 +299,6 @@ public interface NMS<CommandListenerWrapper> {
 
 	BlockData getBlockState(CommandContext<CommandListenerWrapper> cmdCtx, String key);
 
-	/**
-	 * Returns the Brigadier CommandDispatcher from the NMS CommandDispatcher
-	 * 
-	 * @return A Brigadier CommandDispatcher
-	 */
-	CommandDispatcher<CommandListenerWrapper> getBrigadierDispatcher();
-
 	BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException;
 
 	ChatColor getChatColor(CommandContext<CommandListenerWrapper> cmdCtx, String key);
@@ -384,6 +378,28 @@ public interface NMS<CommandListenerWrapper> {
 	String getScoreHolderSingle(CommandContext<CommandListenerWrapper> cmdCtx, String key)
 		throws CommandSyntaxException;
 
+	Team getTeam(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException;
+
+	int getTime(CommandContext<CommandListenerWrapper> cmdCtx, String key);
+
+	UUID getUUID(CommandContext<CommandListenerWrapper> cmdCtx, String key);
+
+	World getWorldForCSS(CommandListenerWrapper clw);
+
+	/**
+	 * Returns the Brigadier CommandDispatcher from the NMS CommandDispatcher
+	 *
+	 * @return A Brigadier CommandDispatcher
+	 */
+	CommandDispatcher<CommandListenerWrapper> getBrigadierDispatcher();
+
+	/**
+	 * Returns the Brigadier CommandDispatcher used when commands are sent to Players
+	 *
+	 * @return A Brigadier CommandDispatcher
+	 */
+	CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher();
+
 	/**
 	 * Returns the Server's internal (OBC) CommandMap
 	 * 
@@ -405,14 +421,6 @@ public interface NMS<CommandListenerWrapper> {
 
 	Set<NamespacedKey> getTags();
 
-	Team getTeam(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException;
-
-	int getTime(CommandContext<CommandListenerWrapper> cmdCtx, String key);
-
-	UUID getUUID(CommandContext<CommandListenerWrapper> cmdCtx, String key);
-
-	World getWorldForCSS(CommandListenerWrapper clw);
-
 	/**
 	 * Checks if a Command is an instance of the OBC VanillaCommandWrapper
 	 * 
@@ -420,6 +428,14 @@ public interface NMS<CommandListenerWrapper> {
 	 * @return true if Command is an instance of VanillaCommandWrapper
 	 */
 	boolean isVanillaCommandWrapper(Command command);
+
+	/**
+	 * Wraps a Brigadier command node as Bukkit's VanillaCommandWrapper
+	 *
+	 * @param node The LiteralCommandNode to wrap
+	 * @return A VanillaCommandWrapper representing the given node
+	 */
+	Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node);
 
 	/**
 	 * Reloads the datapacks by using the updated the commandDispatcher tree

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
@@ -944,7 +944,7 @@ public class NMS_1_15 extends NMSWrapper_1_15 {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommandDispatcher(), node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -514,6 +515,11 @@ public class NMS_1_15 extends NMSWrapper_1_15 {
 	}
 
 	@Override
+	public CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher() {
+		return this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a();
+	}
+
+	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}
@@ -936,6 +942,11 @@ public class NMS_1_15 extends NMSWrapper_1_15 {
 	@Override
 	public boolean isVanillaCommandWrapper(Command command) {
 		return command instanceof VanillaCommandWrapper;
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommandDispatcher(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
@@ -387,10 +387,8 @@ public class NMS_1_15 extends NMSWrapper_1_15 {
 	}
 
 	@Override
-	public void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
@@ -40,6 +41,7 @@ import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.CraftSound;
 import org.bukkit.craftbukkit.v1_15_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_15_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_15_R1.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_15_R1.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_15_R1.enchantments.CraftEnchantment;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -945,6 +947,11 @@ public class NMS_1_15 extends NMSWrapper_1_15 {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
@@ -975,7 +975,7 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommandDispatcher(), node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Differs(from = "1.15", by = "Implement datapack reloading")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -537,6 +538,11 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 	}
 
 	@Override
+	public CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher() {
+		return this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a();
+	}
+
+	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}
@@ -967,6 +973,11 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 	@Override
 	public boolean isVanillaCommandWrapper(Command command) {
 		return command instanceof VanillaCommandWrapper;
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommandDispatcher(), node);
 	}
 
 	@Differs(from = "1.15", by = "Implement datapack reloading")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
@@ -405,10 +405,8 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 	}
 
 	@Override
-	public void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
@@ -45,6 +46,7 @@ import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.CraftSound;
 import org.bukkit.craftbukkit.v1_16_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_16_R1.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_16_R1.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_16_R1.enchantments.CraftEnchantment;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -976,6 +978,11 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Differs(from = "1.15", by = "Implement datapack reloading")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
@@ -961,7 +961,7 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommandDispatcher(), node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
@@ -44,6 +45,7 @@ import org.bukkit.craftbukkit.v1_16_R2.CraftParticle;
 import org.bukkit.craftbukkit.v1_16_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R2.CraftSound;
 import org.bukkit.craftbukkit.v1_16_R2.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_16_R2.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_16_R2.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_16_R2.enchantments.CraftEnchantment;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftEntity;
@@ -962,6 +964,11 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
@@ -404,10 +404,8 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 	}
 
 	@Override
-	public void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -535,6 +536,11 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 	}
 
 	@Override
+	public CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher() {
+		return this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a();
+	}
+
+	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}
@@ -953,6 +959,11 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 	@Override
 	public boolean isVanillaCommandWrapper(Command command) {
 		return command instanceof VanillaCommandWrapper;
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommandDispatcher(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
@@ -354,10 +354,8 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 	public ArgumentType<?> _ArgumentVec3() { return ArgumentVec3.a(); }
 
 	@Override
-	public void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
@@ -64,6 +65,7 @@ import org.bukkit.craftbukkit.v1_16_R3.CraftParticle;
 import org.bukkit.craftbukkit.v1_16_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R3.CraftSound;
 import org.bukkit.craftbukkit.v1_16_R3.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_16_R3.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_16_R3.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_16_R3.enchantments.CraftEnchantment;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftEntity;
@@ -913,6 +915,11 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Differs(from = "1.16.2", by = "CustomFunctionManager.g -> CustomFunctionManager.h")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -491,6 +492,11 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 	}
 
 	@Override
+	public CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher() {
+		return this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a();
+	}
+
+	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}
@@ -904,6 +910,11 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 	@Override
 	public boolean isVanillaCommandWrapper(Command command) {
 		return command instanceof VanillaCommandWrapper;
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommandDispatcher(), node);
 	}
 
 	@Differs(from = "1.16.2", by = "CustomFunctionManager.g -> CustomFunctionManager.h")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
@@ -912,7 +912,7 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommandDispatcher(), node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Differs(from = "1.16.2", by = "CustomFunctionManager.g -> CustomFunctionManager.h")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -58,6 +59,7 @@ import org.bukkit.craftbukkit.v1_17_R1.CraftParticle;
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_17_R1.CraftSound;
 import org.bukkit.craftbukkit.v1_17_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_17_R1.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_17_R1.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_17_R1.help.CustomHelpTopic;
@@ -667,6 +669,11 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
@@ -36,7 +36,6 @@ import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 import com.mojang.brigadier.tree.LiteralCommandNode;
-import dev.jorel.commandapi.preprocessor.Differs;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -241,10 +240,8 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 	}
 
 	@Override
-	public void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
@@ -666,7 +666,7 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import dev.jorel.commandapi.preprocessor.Differs;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -323,8 +325,8 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 	}
 
 	@Override
-	public com.mojang.brigadier.CommandDispatcher<CommandSourceStack> getBrigadierDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher();
+	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
+		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
 	}
 
 	@Override
@@ -663,6 +665,11 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 	@Override
 	public boolean isVanillaCommandWrapper(Command command) {
 		return command instanceof VanillaCommandWrapper;
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -61,6 +62,7 @@ import org.bukkit.craftbukkit.v1_18_R2.CraftParticle;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_18_R2.CraftSound;
 import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_18_R2.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_18_R2.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_18_R2.help.CustomHelpTopic;
@@ -715,6 +717,11 @@ public class NMS_1_18_R2 extends NMS_Common {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Differs(from = "1.18", by = "Completely rewritten way of reloading datapacks")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
@@ -714,7 +714,7 @@ public class NMS_1_18_R2 extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Differs(from = "1.18", by = "Completely rewritten way of reloading datapacks")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -382,8 +383,8 @@ public class NMS_1_18_R2 extends NMS_Common {
 	}
 
 	@Override
-	public com.mojang.brigadier.CommandDispatcher<CommandSourceStack> getBrigadierDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher();
+	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
+		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
 	}
 
 	@Override
@@ -711,6 +712,11 @@ public class NMS_1_18_R2 extends NMS_Common {
 	@Override
 	public boolean isVanillaCommandWrapper(Command command) {
 		return command instanceof VanillaCommandWrapper;
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Differs(from = "1.18", by = "Completely rewritten way of reloading datapacks")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
@@ -260,10 +260,8 @@ public class NMS_1_18_R2 extends NMS_Common {
 	}
 	
 	@Override
-	public void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -60,6 +61,7 @@ import org.bukkit.craftbukkit.v1_18_R1.CraftParticle;
 import org.bukkit.craftbukkit.v1_18_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_18_R1.CraftSound;
 import org.bukkit.craftbukkit.v1_18_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_18_R1.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_18_R1.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_18_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_18_R1.help.CustomHelpTopic;
@@ -659,6 +661,11 @@ public class NMS_1_18_R1 extends NMS_Common {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -328,8 +329,9 @@ public class NMS_1_18_R1 extends NMS_Common {
 	}
 
 	@Override
-	public com.mojang.brigadier.CommandDispatcher<CommandSourceStack> getBrigadierDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher();
+	@Differs(from = "1.17", by = "MinecraftServer#getCommands -> MinecraftServer#aA")
+	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
+		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
 	}
 
 	@Override
@@ -654,6 +656,11 @@ public class NMS_1_18_R1 extends NMS_Common {
 	@Override
 	public boolean isVanillaCommandWrapper(Command command) {
 		return command instanceof VanillaCommandWrapper;
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
@@ -244,10 +244,8 @@ public class NMS_1_18_R1 extends NMS_Common {
 	}
 	
 	@Override
-	public void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
@@ -658,7 +658,7 @@ public class NMS_1_18_R1 extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
@@ -31,6 +31,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.logging.LogUtils;
 import dev.jorel.commandapi.CommandAPI;
@@ -114,6 +115,7 @@ import org.bukkit.craftbukkit.v1_19_R1.CraftParticle;
 import org.bukkit.craftbukkit.v1_19_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R1.CraftSound;
 import org.bukkit.craftbukkit.v1_19_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_19_R1.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_19_R1.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_19_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
@@ -738,6 +740,11 @@ public abstract class NMS_1_19_Common extends NMS_Common {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
@@ -737,7 +737,7 @@ public abstract class NMS_1_19_Common extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
@@ -314,10 +314,10 @@ public abstract class NMS_1_19_Common extends NMS_Common {
 	}
 
 	@Override
-	public final void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
+	public final Map<String, HelpTopic> getHelpMap() {
 		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
 		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
@@ -225,10 +225,8 @@ public class NMS_1_19_3_R2 extends NMS_Common {
 	}
 
 	@Override
-	public final void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public final Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
@@ -20,56 +20,6 @@
  *******************************************************************************/
 package dev.jorel.commandapi.nms;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.lang.reflect.Field;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Predicate;
-import java.util.function.ToIntFunction;
-
-import dev.jorel.commandapi.CommandAPIHandler;
-import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
-import org.bukkit.Particle;
-import org.bukkit.Particle.DustOptions;
-import org.bukkit.Particle.DustTransition;
-import org.bukkit.Vibration;
-import org.bukkit.Vibration.Destination;
-import org.bukkit.Vibration.Destination.BlockDestination;
-import org.bukkit.World;
-import org.bukkit.block.Biome;
-import org.bukkit.block.Block;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.SimpleCommandMap;
-import org.bukkit.craftbukkit.v1_19_R2.CraftLootTable;
-import org.bukkit.craftbukkit.v1_19_R2.CraftParticle;
-import org.bukkit.craftbukkit.v1_19_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_19_R2.CraftSound;
-import org.bukkit.craftbukkit.v1_19_R2.block.data.CraftBlockData;
-import org.bukkit.craftbukkit.v1_19_R2.command.VanillaCommandWrapper;
-import org.bukkit.craftbukkit.v1_19_R2.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_19_R2.help.CustomHelpTopic;
-import org.bukkit.craftbukkit.v1_19_R2.help.SimpleHelpMap;
-import org.bukkit.craftbukkit.v1_19_R2.inventory.CraftItemStack;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.help.HelpTopic;
-import org.bukkit.inventory.Recipe;
-import org.bukkit.potion.PotionEffectType;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import com.google.gson.GsonBuilder;
@@ -80,9 +30,10 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.logging.LogUtils;
-
 import dev.jorel.commandapi.CommandAPI;
+import dev.jorel.commandapi.CommandAPIHandler;
 import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
@@ -92,12 +43,7 @@ import dev.jorel.commandapi.commandsenders.BukkitNativeProxyCommandSender;
 import dev.jorel.commandapi.preprocessor.Differs;
 import dev.jorel.commandapi.preprocessor.NMSMeta;
 import dev.jorel.commandapi.preprocessor.RequireField;
-import dev.jorel.commandapi.wrappers.ComplexRecipeImpl;
-import dev.jorel.commandapi.wrappers.FunctionWrapper;
-import dev.jorel.commandapi.wrappers.Location2D;
-import dev.jorel.commandapi.wrappers.NativeProxyCommandSender;
-import dev.jorel.commandapi.wrappers.ParticleData;
-import dev.jorel.commandapi.wrappers.SimpleFunctionWrapper;
+import dev.jorel.commandapi.wrappers.*;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
@@ -106,13 +52,7 @@ import net.minecraft.commands.CommandFunction;
 import net.minecraft.commands.CommandFunction.Entry;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.SharedSuggestionProvider;
-import net.minecraft.commands.arguments.ColorArgument;
-import net.minecraft.commands.arguments.ComponentArgument;
-import net.minecraft.commands.arguments.DimensionArgument;
-import net.minecraft.commands.arguments.EntityArgument;
-import net.minecraft.commands.arguments.ParticleArgument;
-import net.minecraft.commands.arguments.ResourceArgument;
-import net.minecraft.commands.arguments.ResourceLocationArgument;
+import net.minecraft.commands.arguments.*;
 import net.minecraft.commands.arguments.blocks.BlockPredicateArgument;
 import net.minecraft.commands.arguments.blocks.BlockStateArgument;
 import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
@@ -127,15 +67,7 @@ import net.minecraft.commands.arguments.selector.EntitySelector;
 import net.minecraft.commands.synchronization.ArgumentUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.RegistryAccess.Frozen;
-import net.minecraft.core.particles.BlockParticleOption;
-import net.minecraft.core.particles.DustColorTransitionOptions;
-import net.minecraft.core.particles.DustParticleOptions;
-import net.minecraft.core.particles.ItemParticleOption;
-import net.minecraft.core.particles.ParticleOptions;
-import net.minecraft.core.particles.SculkChargeParticleOptions;
-import net.minecraft.core.particles.ShriekParticleOption;
-import net.minecraft.core.particles.SimpleParticleType;
-import net.minecraft.core.particles.VibrationParticleOption;
+import net.minecraft.core.particles.*;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
@@ -164,6 +96,44 @@ import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.level.gameevent.BlockPositionSource;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.*;
+import org.bukkit.Particle.DustOptions;
+import org.bukkit.Particle.DustTransition;
+import org.bukkit.Vibration.Destination;
+import org.bukkit.Vibration.Destination.BlockDestination;
+import org.bukkit.block.Biome;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.craftbukkit.v1_19_R2.CraftLootTable;
+import org.bukkit.craftbukkit.v1_19_R2.CraftParticle;
+import org.bukkit.craftbukkit.v1_19_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_19_R2.CraftSound;
+import org.bukkit.craftbukkit.v1_19_R2.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_19_R2.command.VanillaCommandWrapper;
+import org.bukkit.craftbukkit.v1_19_R2.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_19_R2.help.CustomHelpTopic;
+import org.bukkit.craftbukkit.v1_19_R2.help.SimpleHelpMap;
+import org.bukkit.craftbukkit.v1_19_R2.inventory.CraftItemStack;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.help.HelpTopic;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.potion.PotionEffectType;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
 
 // Mojang-Mapped reflection
 /**
@@ -342,8 +312,9 @@ public class NMS_1_19_3_R2 extends NMS_Common {
 	}
 
 	@Override
-	public final com.mojang.brigadier.CommandDispatcher<CommandSourceStack> getBrigadierDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher();
+	@Differs(from = "1.19, 1.19.1, 1.19.2", by = "MinecraftServer#aC -> MinecraftServer#aB")
+	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
+		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
 	}
 
 	@Override
@@ -654,6 +625,11 @@ public class NMS_1_19_3_R2 extends NMS_Common {
 	@Override
 	public final boolean isVanillaCommandWrapper(Command command) {
 		return command instanceof VanillaCommandWrapper;
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Differs(from = "1.19.2", by = """

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
@@ -30,6 +30,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.logging.LogUtils;
 import dev.jorel.commandapi.CommandAPI;
@@ -112,6 +113,7 @@ import org.bukkit.craftbukkit.v1_19_R2.CraftParticle;
 import org.bukkit.craftbukkit.v1_19_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R2.CraftSound;
 import org.bukkit.craftbukkit.v1_19_R2.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_19_R2.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_19_R2.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_19_R2.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_19_R2.help.CustomHelpTopic;
@@ -628,6 +630,11 @@ public class NMS_1_19_3_R2 extends NMS_Common {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Differs(from = "1.19.2", by = """

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
@@ -30,6 +30,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.logging.LogUtils;
 import dev.jorel.commandapi.CommandAPI;
@@ -112,6 +113,7 @@ import org.bukkit.craftbukkit.v1_19_R3.CraftParticle;
 import org.bukkit.craftbukkit.v1_19_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R3.CraftSound;
 import org.bukkit.craftbukkit.v1_19_R3.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_19_R3.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_19_R3.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_19_R3.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_19_R3.help.CustomHelpTopic;
@@ -621,6 +623,11 @@ public class NMS_1_19_4_R3 extends NMS_Common {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
@@ -224,10 +224,8 @@ public class NMS_1_19_4_R3 extends NMS_Common {
 	}
 
 	@Override
-	public final void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public final Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
@@ -30,6 +30,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.logging.LogUtils;
 import dev.jorel.commandapi.CommandAPI;
@@ -113,6 +114,7 @@ import org.bukkit.craftbukkit.v1_20_R1.CraftParticle;
 import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R1.CraftSound;
 import org.bukkit.craftbukkit.v1_20_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_20_R1.command.BukkitCommandWrapper;
 import org.bukkit.craftbukkit.v1_20_R1.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_20_R1.help.CustomHelpTopic;
@@ -621,6 +623,11 @@ public class NMS_1_20_R1 extends NMS_Common {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return node.getCommand() instanceof BukkitCommandWrapper;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
@@ -20,56 +20,6 @@
  *******************************************************************************/
 package dev.jorel.commandapi.nms;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.lang.reflect.Field;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Predicate;
-import java.util.function.ToIntFunction;
-
-import dev.jorel.commandapi.CommandAPIHandler;
-import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
-import org.bukkit.Particle;
-import org.bukkit.Particle.DustOptions;
-import org.bukkit.Particle.DustTransition;
-import org.bukkit.Vibration;
-import org.bukkit.Vibration.Destination;
-import org.bukkit.Vibration.Destination.BlockDestination;
-import org.bukkit.World;
-import org.bukkit.block.Biome;
-import org.bukkit.block.Block;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.SimpleCommandMap;
-import org.bukkit.craftbukkit.v1_20_R1.CraftLootTable;
-import org.bukkit.craftbukkit.v1_20_R1.CraftParticle;
-import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_20_R1.CraftSound;
-import org.bukkit.craftbukkit.v1_20_R1.block.data.CraftBlockData;
-import org.bukkit.craftbukkit.v1_20_R1.command.VanillaCommandWrapper;
-import org.bukkit.craftbukkit.v1_20_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_20_R1.help.CustomHelpTopic;
-import org.bukkit.craftbukkit.v1_20_R1.help.SimpleHelpMap;
-import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.help.HelpTopic;
-import org.bukkit.inventory.Recipe;
-import org.bukkit.potion.PotionEffectType;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import com.google.gson.GsonBuilder;
@@ -80,9 +30,10 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.logging.LogUtils;
-
 import dev.jorel.commandapi.CommandAPI;
+import dev.jorel.commandapi.CommandAPIHandler;
 import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
@@ -92,12 +43,7 @@ import dev.jorel.commandapi.commandsenders.BukkitNativeProxyCommandSender;
 import dev.jorel.commandapi.preprocessor.Differs;
 import dev.jorel.commandapi.preprocessor.NMSMeta;
 import dev.jorel.commandapi.preprocessor.RequireField;
-import dev.jorel.commandapi.wrappers.ComplexRecipeImpl;
-import dev.jorel.commandapi.wrappers.FunctionWrapper;
-import dev.jorel.commandapi.wrappers.Location2D;
-import dev.jorel.commandapi.wrappers.NativeProxyCommandSender;
-import dev.jorel.commandapi.wrappers.ParticleData;
-import dev.jorel.commandapi.wrappers.SimpleFunctionWrapper;
+import dev.jorel.commandapi.wrappers.*;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
@@ -106,13 +52,7 @@ import net.minecraft.commands.CommandFunction;
 import net.minecraft.commands.CommandFunction.Entry;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.SharedSuggestionProvider;
-import net.minecraft.commands.arguments.ColorArgument;
-import net.minecraft.commands.arguments.ComponentArgument;
-import net.minecraft.commands.arguments.DimensionArgument;
-import net.minecraft.commands.arguments.EntityArgument;
-import net.minecraft.commands.arguments.ParticleArgument;
-import net.minecraft.commands.arguments.ResourceArgument;
-import net.minecraft.commands.arguments.ResourceLocationArgument;
+import net.minecraft.commands.arguments.*;
 import net.minecraft.commands.arguments.blocks.BlockPredicateArgument;
 import net.minecraft.commands.arguments.blocks.BlockStateArgument;
 import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
@@ -127,15 +67,7 @@ import net.minecraft.commands.arguments.selector.EntitySelector;
 import net.minecraft.commands.synchronization.ArgumentUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.RegistryAccess.Frozen;
-import net.minecraft.core.particles.BlockParticleOption;
-import net.minecraft.core.particles.DustColorTransitionOptions;
-import net.minecraft.core.particles.DustParticleOptions;
-import net.minecraft.core.particles.ItemParticleOption;
-import net.minecraft.core.particles.ParticleOptions;
-import net.minecraft.core.particles.SculkChargeParticleOptions;
-import net.minecraft.core.particles.ShriekParticleOption;
-import net.minecraft.core.particles.SimpleParticleType;
-import net.minecraft.core.particles.VibrationParticleOption;
+import net.minecraft.core.particles.*;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
@@ -165,6 +97,44 @@ import net.minecraft.world.level.gameevent.BlockPositionSource;
 import net.minecraft.world.level.storage.loot.LootDataType;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.*;
+import org.bukkit.Particle.DustOptions;
+import org.bukkit.Particle.DustTransition;
+import org.bukkit.Vibration.Destination;
+import org.bukkit.Vibration.Destination.BlockDestination;
+import org.bukkit.block.Biome;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.craftbukkit.v1_20_R1.CraftLootTable;
+import org.bukkit.craftbukkit.v1_20_R1.CraftParticle;
+import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_20_R1.CraftSound;
+import org.bukkit.craftbukkit.v1_20_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_20_R1.command.VanillaCommandWrapper;
+import org.bukkit.craftbukkit.v1_20_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_20_R1.help.CustomHelpTopic;
+import org.bukkit.craftbukkit.v1_20_R1.help.SimpleHelpMap;
+import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.help.HelpTopic;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.potion.PotionEffectType;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
 
 // Mojang-Mapped reflection
 /**
@@ -253,10 +223,8 @@ public class NMS_1_20_R1 extends NMS_Common {
 	}
 
 	@Override
-	public final void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We have to use VarHandles to use helpTopics.put (instead of .addTopic)
-		// because we're updating an existing help topic, not adding a new help topic
-		helpMapTopics.get((SimpleHelpMap) Bukkit.getServer().getHelpMap()).putAll(helpTopicsToAdd);
+	public final Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((SimpleHelpMap) Bukkit.getHelpMap());
 	}
 
 	@Override
@@ -339,8 +307,8 @@ public class NMS_1_20_R1 extends NMS_Common {
 	}
 
 	@Override
-	public final com.mojang.brigadier.CommandDispatcher<CommandSourceStack> getBrigadierDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher();
+	public final CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
+		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
 	}
 
 	@Override
@@ -648,6 +616,11 @@ public class NMS_1_20_R1 extends NMS_Common {
 	@Override
 	public final boolean isVanillaCommandWrapper(Command command) {
 		return command instanceof VanillaCommandWrapper;
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
@@ -25,6 +25,7 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.CommandAPIBukkit;
 import dev.jorel.commandapi.CommandAPIHandler;
@@ -640,6 +641,10 @@ public abstract class NMS_Common extends CommandAPIBukkit<CommandSourceStack> {
 	@Override
 	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "VanillaCommandWrapper")
 	public abstract Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node);
+
+	@Override
+	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "VanillaCommandWrapper")
+	public abstract boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node);
 
 	@Override
 	@Unimplemented(because = VERSION_SPECIFIC_IMPLEMENTATION)

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
@@ -274,7 +274,7 @@ public abstract class NMS_Common extends CommandAPIBukkit<CommandSourceStack> {
 
 	@Override
 	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "SimpleHelpMap")
-	public abstract void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd);
+	public abstract Map<String, HelpTopic> getHelpMap();
 
 	@Override
 	@Unimplemented(because = VERSION_SPECIFIC_IMPLEMENTATION)

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
@@ -20,35 +20,39 @@
  *******************************************************************************/
 package dev.jorel.commandapi.nms;
 
-import static dev.jorel.commandapi.preprocessor.Unimplemented.REASON.NAME_CHANGED;
-import static dev.jorel.commandapi.preprocessor.Unimplemented.REASON.REQUIRES_CRAFTBUKKIT;
-import static dev.jorel.commandapi.preprocessor.Unimplemented.REASON.REQUIRES_CSS;
-import static dev.jorel.commandapi.preprocessor.Unimplemented.REASON.VERSION_SPECIFIC_IMPLEMENTATION;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.ToIntFunction;
-
-import javax.annotation.Nullable;
-
-import org.bukkit.Axis;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.Sound;
-import org.bukkit.World;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import dev.jorel.commandapi.CommandAPIBukkit;
+import dev.jorel.commandapi.CommandAPIHandler;
+import dev.jorel.commandapi.arguments.ArgumentSubType;
+import dev.jorel.commandapi.arguments.SuggestionProviders;
+import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
+import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
+import dev.jorel.commandapi.preprocessor.Differs;
+import dev.jorel.commandapi.preprocessor.Overridden;
+import dev.jorel.commandapi.preprocessor.Unimplemented;
+import dev.jorel.commandapi.wrappers.Rotation;
+import dev.jorel.commandapi.wrappers.*;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
+import net.minecraft.advancements.critereon.MinMaxBounds;
+import net.minecraft.commands.CommandFunction;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.*;
+import net.minecraft.commands.arguments.coordinates.*;
+import net.minecraft.commands.arguments.item.FunctionArgument;
+import net.minecraft.network.chat.Component.Serializer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.phys.Vec2;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.command.Command;
@@ -65,66 +69,14 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Team;
 
-import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.arguments.ArgumentType;
-import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.suggestion.SuggestionProvider;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
 
-import dev.jorel.commandapi.CommandAPIBukkit;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.arguments.ArgumentSubType;
-import dev.jorel.commandapi.arguments.SuggestionProviders;
-import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
-import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
-import dev.jorel.commandapi.preprocessor.Differs;
-import dev.jorel.commandapi.preprocessor.Overridden;
-import dev.jorel.commandapi.preprocessor.Unimplemented;
-import dev.jorel.commandapi.wrappers.FloatRange;
-import dev.jorel.commandapi.wrappers.FunctionWrapper;
-import dev.jorel.commandapi.wrappers.IntegerRange;
-import dev.jorel.commandapi.wrappers.Location2D;
-import dev.jorel.commandapi.wrappers.MathOperation;
-import dev.jorel.commandapi.wrappers.ParticleData;
-import dev.jorel.commandapi.wrappers.Rotation;
-import dev.jorel.commandapi.wrappers.ScoreboardSlot;
-import dev.jorel.commandapi.wrappers.SimpleFunctionWrapper;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
-import net.minecraft.advancements.critereon.MinMaxBounds;
-import net.minecraft.commands.CommandFunction;
-import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.arguments.AngleArgument;
-import net.minecraft.commands.arguments.ColorArgument;
-import net.minecraft.commands.arguments.ComponentArgument;
-import net.minecraft.commands.arguments.CompoundTagArgument;
-import net.minecraft.commands.arguments.DimensionArgument;
-import net.minecraft.commands.arguments.GameProfileArgument;
-import net.minecraft.commands.arguments.MessageArgument;
-import net.minecraft.commands.arguments.ObjectiveArgument;
-import net.minecraft.commands.arguments.ObjectiveCriteriaArgument;
-import net.minecraft.commands.arguments.OperationArgument;
-import net.minecraft.commands.arguments.RangeArgument;
-import net.minecraft.commands.arguments.ResourceLocationArgument;
-import net.minecraft.commands.arguments.ScoreHolderArgument;
-import net.minecraft.commands.arguments.ScoreboardSlotArgument;
-import net.minecraft.commands.arguments.TeamArgument;
-import net.minecraft.commands.arguments.TimeArgument;
-import net.minecraft.commands.arguments.UuidArgument;
-import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
-import net.minecraft.commands.arguments.coordinates.ColumnPosArgument;
-import net.minecraft.commands.arguments.coordinates.RotationArgument;
-import net.minecraft.commands.arguments.coordinates.SwizzleArgument;
-import net.minecraft.commands.arguments.coordinates.Vec2Argument;
-import net.minecraft.commands.arguments.coordinates.Vec3Argument;
-import net.minecraft.commands.arguments.item.FunctionArgument;
-import net.minecraft.network.chat.Component.Serializer;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.phys.Vec2;
+import static dev.jorel.commandapi.preprocessor.Unimplemented.REASON.*;
 
 /**
  * Common NMS code To ensure that this code actually works across all versions
@@ -411,11 +363,14 @@ public abstract class NMS_Common extends CommandAPIBukkit<CommandSourceStack> {
 	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "CraftBlockData")
 	public abstract BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key);
 
-	@SuppressWarnings("resource")
 	@Override
-	public CommandDispatcher<CommandSourceStack> getBrigadierDispatcher() {
+	public final CommandDispatcher<CommandSourceStack> getBrigadierDispatcher() {
 		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher();
 	}
+
+	@Override
+	@Unimplemented(because = NAME_CHANGED, info = "MinecraftServer#getCommands() obfuscated differently across multiple versions")
+	public abstract CommandDispatcher<CommandSourceStack> getResourcesDispatcher();
 
 	@Override
 	public final BaseComponent[] getChat(CommandContext<CommandSourceStack> cmdCtx, String key) throws CommandSyntaxException {
@@ -681,6 +636,10 @@ public abstract class NMS_Common extends CommandAPIBukkit<CommandSourceStack> {
 	@Override
 	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "VanillaCommandWrapper")
 	public abstract boolean isVanillaCommandWrapper(Command command);
+
+	@Override
+	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "VanillaCommandWrapper")
+	public abstract Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node);
 
 	@Override
 	@Unimplemented(because = VERSION_SPECIFIC_IMPLEMENTATION)

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -20,27 +20,26 @@
  *******************************************************************************/
 package dev.jorel.commandapi;
 
-import de.tr7zw.changeme.nbtapi.NBTContainer;
-import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
-import dev.jorel.commandapi.arguments.GreedyStringArgument;
-import dev.jorel.commandapi.arguments.StringArgument;
-import org.bukkit.Bukkit;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.plugin.InvalidPluginException;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.java.JavaPlugin;
-
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.InvalidPluginException;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import de.tr7zw.changeme.nbtapi.NBTContainer;
+import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
+
 /**
  * Main CommandAPI plugin entrypoint
  */
 public class CommandAPIMain extends JavaPlugin {
-	
+
 	private static final String PLUGINS_TO_CONVERT = "plugins-to-convert";
 
 	@Override
@@ -85,7 +84,7 @@ public class CommandAPIMain extends JavaPlugin {
 
 		convertCommands(fileConfig);
 	}
-	
+
 	private void convertCommands(FileConfiguration fileConfig) {
 		// Load all plugins at the same time
 		Map<JavaPlugin, String[]> pluginsToConvert = new HashMap<>();
@@ -102,7 +101,7 @@ public class CommandAPIMain extends JavaPlugin {
 			// Get the plugin, if it doesn't exist, scream in the console (but
 			// don't crash, we want to continue!)
 			final JavaPlugin plugin = getAndValidatePlugin((String) map.keySet().iterator().next());
-			if(plugin != null) {
+			if (plugin != null) {
 				pluginsToConvert.put(plugin, pluginCommands);
 			}
 		}
@@ -123,7 +122,7 @@ public class CommandAPIMain extends JavaPlugin {
 			new AdvancedConverter(commandName).convertCommand();
 		}
 	}
-	
+
 	private JavaPlugin getAndValidatePlugin(String pluginName) {
 		Plugin plugin = Bukkit.getPluginManager().getPlugin(pluginName);
 		if (plugin != null) {
@@ -142,49 +141,5 @@ public class CommandAPIMain extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		CommandAPI.onEnable();
-
-		new CommandAPICommand("register")
-			.withArguments(new StringArgument("command"))
-			.withOptionalArguments(
-				new GreedyStringArgument("aliases")
-			)
-			.executes(info -> {
-				String name = info.args().getUnchecked("command");
-				assert name != null;
-
-				String aliasString = info.args().getUnchecked("aliases");
-				String[] aliases;
-				if(aliasString == null)
-					aliases = new String[0];
-				else
-					aliases = aliasString.split(" ");
-
-				new CommandAPICommand(name)
-					.withAliases(aliases)
-					.executes(i -> {
-						i.sender().sendMessage("You ran the " + name + " command!");
-					})
-					.withPermission("dynamic." + name)
-					.withShortDescription("New command!")
-					.withFullDescription("This command was added while the server was running. Do you see it?")
-					.register();
-			})
-			.register();
-
-		new CommandAPICommand("unregister")
-			.withArguments(new StringArgument("command"))
-			.executes(info -> {
-				String name = info.args().getUnchecked("command");
-				assert name != null;
-
-				CommandAPI.unregister(name, true);
-			})
-			.register();
-
-		new CommandAPICommand("updateRequirements")
-			.executesPlayer(info -> {
-				CommandAPI.updateRequirements(info.sender());
-			})
-			.register();
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
@@ -54,10 +54,10 @@ import net.minecraft.server.v1_16_R3.CommandListenerWrapper;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public abstract class ArgumentNMS extends MockPlatform<CommandListenerWrapper> {
 
-	CommandAPIBukkit<?> baseNMS;
+	CommandAPIBukkit<CommandListenerWrapper> baseNMS;
 
 	protected ArgumentNMS(CommandAPIBukkit<?> baseNMS) {
-		this.baseNMS = baseNMS;
+		this.baseNMS = (CommandAPIBukkit<CommandListenerWrapper>) baseNMS;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.SafeVarHandle;
 import org.bukkit.Bukkit;
@@ -277,6 +278,11 @@ public class MockNMS extends Enums {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node) {
 		return baseNMS.wrapToVanillaCommandWrapper(node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node) {
+		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -19,7 +19,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import dev.jorel.commandapi.SafeVarHandle;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -91,6 +93,8 @@ import net.minecraft.server.v1_16_R3.Vec3D;
 import net.minecraft.server.v1_16_R3.WorldServer;
 
 public class MockNMS extends Enums {
+	private static final SafeVarHandle<HelpMapMock, Map<String, HelpTopic>> helpMapTopics =
+		SafeVarHandle.ofOrNull(HelpMapMock.class, "topics", "topics", Map.class);
 
 	static {
 		CodeSource src = PotionEffectType.class.getProtectionDomain().getCodeSource();
@@ -589,4 +593,8 @@ public class MockNMS extends Enums {
 		return baseNMS.generateHelpTopic(commandName, shortDescription, fullDescription, permission);
 	}
 
+	@Override
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
@@ -54,10 +54,10 @@ import net.minecraft.commands.CommandSourceStack;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public abstract class ArgumentNMS extends MockPlatform<CommandSourceStack> {
 
-	CommandAPIBukkit<?> baseNMS;
+	CommandAPIBukkit<CommandSourceStack> baseNMS;
 
 	protected ArgumentNMS(CommandAPIBukkit<?> baseNMS) {
-		this.baseNMS = baseNMS;
+		this.baseNMS = (CommandAPIBukkit<CommandSourceStack>) baseNMS;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -18,12 +18,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.World;
+import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_17_R1.CraftParticle;
@@ -104,7 +106,7 @@ public class MockNMS extends Enums {
 		super(baseNMS);
 
 		// Stub in our getMinecraftServer implementation
-		CommandAPIBukkit<?> nms = Mockito.spy(super.baseNMS);
+		CommandAPIBukkit<CommandSourceStack> nms = Mockito.spy(super.baseNMS);
 		Mockito.when(nms.getMinecraftServer()).thenAnswer(i -> getMinecraftServer());
 		super.baseNMS = nms;
 
@@ -130,6 +132,18 @@ public class MockNMS extends Enums {
 		this.recipeManager = new RecipeManager();
 		this.functions = new HashMap<>();
 		registerDefaultRecipes();
+
+		// Set up playerListMock
+		playerListMock = Mockito.mock(PlayerList.class);
+		Mockito.when(playerListMock.getPlayerByName(anyString())).thenAnswer(invocation -> {
+			String playerName = invocation.getArgument(0);
+			for (ServerPlayer onlinePlayer : players) {
+				if (onlinePlayer.getBukkitEntity().getName().equals(playerName)) {
+					return onlinePlayer;
+				}
+			}
+			return null;
+		});
 	}
 
 	/*************************
@@ -244,6 +258,16 @@ public class MockNMS extends Enums {
 	}
 
 	@Override
+	public boolean isVanillaCommandWrapper(Command command) {
+		return baseNMS.isVanillaCommandWrapper(command);
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
+		return baseNMS.wrapToVanillaCommandWrapper(node);
+	}
+
+	@Override
 	public CommandSourceStack getBrigadierSourceFromCommandSender(AbstractCommandSender<? extends CommandSender> senderWrapper) {
 		CommandSender sender = senderWrapper.getSource();
 		CommandSourceStack css = Mockito.mock(CommandSourceStack.class);
@@ -272,19 +296,6 @@ public class MockNMS extends Enums {
 				Mockito.when(entityPlayerMock.getBukkitEntity()).thenReturn(craftPlayerMock);
 				Mockito.when(entityPlayerMock.getDisplayName()).thenReturn(new TextComponent(onlinePlayer.getName())); // ChatArgument, AdventureChatArgument
 				players.add(entityPlayerMock);
-			}
-
-			if (playerListMock == null) {
-				playerListMock = Mockito.mock(PlayerList.class);
-				Mockito.when(playerListMock.getPlayerByName(anyString())).thenAnswer(invocation -> {
-					String playerName = invocation.getArgument(0);
-					for (ServerPlayer onlinePlayer : players) {
-						if (onlinePlayer.getBukkitEntity().getName().equals(playerName)) {
-							return onlinePlayer;
-						}
-					}
-					return null;
-				});
 			}
 
 			// CommandSourceStack#levels

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -18,7 +18,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import dev.jorel.commandapi.SafeVarHandle;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -92,6 +94,8 @@ import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria.RenderType;
 
 public class MockNMS extends Enums {
+	private static final SafeVarHandle<HelpMapMock, Map<String, HelpTopic>> helpMapTopics =
+		SafeVarHandle.ofOrNull(HelpMapMock.class, "topics", "topics", Map.class);
 
 	static ServerAdvancementManager advancementDataWorld = new ServerAdvancementManager(null);
 
@@ -579,4 +583,8 @@ public class MockNMS extends Enums {
 		return baseNMS.generateHelpTopic(commandName, shortDescription, fullDescription, permission);
 	}
 
+	@Override
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -6,21 +6,14 @@ import static org.mockito.ArgumentMatchers.anyString;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.SafeVarHandle;
+import net.minecraft.commands.Commands;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -295,10 +288,15 @@ public class MockNMS extends Enums {
 			for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
 				ServerPlayer entityPlayerMock = Mockito.mock(ServerPlayer.class);
 				CraftPlayer craftPlayerMock = Mockito.mock(CraftPlayer.class);
-				Mockito.when(craftPlayerMock.getName()).thenReturn(onlinePlayer.getName());
-				Mockito.when(craftPlayerMock.getUniqueId()).thenReturn(onlinePlayer.getUniqueId());
+
+				// Extract these variables first in case the onlinePlayer is a Mockito object itself
+				String name = onlinePlayer.getName();
+				UUID uuid = onlinePlayer.getUniqueId();
+
+				Mockito.when(craftPlayerMock.getName()).thenReturn(name);
+				Mockito.when(craftPlayerMock.getUniqueId()).thenReturn(uuid);
 				Mockito.when(entityPlayerMock.getBukkitEntity()).thenReturn(craftPlayerMock);
-				Mockito.when(entityPlayerMock.getDisplayName()).thenReturn(new TextComponent(onlinePlayer.getName())); // ChatArgument, AdventureChatArgument
+				Mockito.when(entityPlayerMock.getDisplayName()).thenReturn(new TextComponent(name)); // ChatArgument, AdventureChatArgument
 				players.add(entityPlayerMock);
 			}
 
@@ -516,6 +514,11 @@ public class MockNMS extends Enums {
 		Mockito.when(minecraftServerMock.getGameRules()).thenAnswer(i -> new GameRules());
 		Mockito.when(minecraftServerMock.getProfiler()).thenAnswer(i -> InactiveMetricsRecorder.INSTANCE.getProfiler());
 
+		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
+		Commands commands = new Commands();
+		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
+		minecraftServerMock.vanillaCommandDispatcher = commands;
+
 		return (T) minecraftServerMock;
 	}
 
@@ -549,6 +552,11 @@ public class MockNMS extends Enums {
 			tagFunctions.add(CommandFunction.fromLines(resourceLocation, Brigadier.getCommandDispatcher(), css, functionCommands));
 		}
 		this.tags.put(resourceLocation, tagFunctions);
+	}
+
+	@Override
+	public Class<? extends Player> getCraftPlayerClass() {
+		return CraftPlayer.class;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.SafeVarHandle;
 import net.minecraft.commands.Commands;
@@ -262,6 +263,11 @@ public class MockNMS extends Enums {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return baseNMS.wrapToVanillaCommandWrapper(node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
@@ -54,10 +54,10 @@ import net.minecraft.commands.CommandSourceStack;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public abstract class ArgumentNMS extends MockPlatform<CommandSourceStack> {
 
-	CommandAPIBukkit<?> baseNMS;
+	CommandAPIBukkit<CommandSourceStack> baseNMS;
 
 	protected ArgumentNMS(CommandAPIBukkit<?> baseNMS) {
-		this.baseNMS = baseNMS;
+		this.baseNMS = (CommandAPIBukkit<CommandSourceStack>) baseNMS;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -7,22 +7,14 @@ import static org.mockito.ArgumentMatchers.anyString;
 import java.io.File;
 import java.io.IOException;
 import java.security.CodeSource;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.SafeVarHandle;
+import net.minecraft.commands.Commands;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -314,10 +306,15 @@ public class MockNMS extends Enums {
 			for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
 				ServerPlayer entityPlayerMock = Mockito.mock(ServerPlayer.class);
 				CraftPlayer craftPlayerMock = Mockito.mock(CraftPlayer.class);
-				Mockito.when(craftPlayerMock.getName()).thenReturn(onlinePlayer.getName());
-				Mockito.when(craftPlayerMock.getUniqueId()).thenReturn(onlinePlayer.getUniqueId());
+
+				// Extract these variables first in case the onlinePlayer is a Mockito object itself
+				String name = onlinePlayer.getName();
+				UUID uuid = onlinePlayer.getUniqueId();
+
+				Mockito.when(craftPlayerMock.getName()).thenReturn(name);
+				Mockito.when(craftPlayerMock.getUniqueId()).thenReturn(uuid);
 				Mockito.when(entityPlayerMock.getBukkitEntity()).thenReturn(craftPlayerMock);
-				Mockito.when(entityPlayerMock.getDisplayName()).thenReturn(new TextComponent(onlinePlayer.getName())); // ChatArgument, AdventureChatArgument
+				Mockito.when(entityPlayerMock.getDisplayName()).thenReturn(new TextComponent(name)); // ChatArgument, AdventureChatArgument
 				players.add(entityPlayerMock);
 			}
 
@@ -532,6 +529,11 @@ public class MockNMS extends Enums {
 		Mockito.when(minecraftServerMock.getGameRules()).thenAnswer(i -> new GameRules());
 		Mockito.when(minecraftServerMock.getProfiler()).thenAnswer(i -> InactiveMetricsRecorder.INSTANCE.getProfiler());
 
+		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
+		Commands commands = new Commands();
+		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
+		minecraftServerMock.vanillaCommandDispatcher = commands;
+
 		return (T) minecraftServerMock;
 	}
 
@@ -565,6 +567,11 @@ public class MockNMS extends Enums {
 			tagFunctions.add(CommandFunction.fromLines(resourceLocation, Brigadier.getCommandDispatcher(), css, functionCommands));
 		}
 		this.tags.put(resourceLocation, tagFunctions);
+	}
+
+	@Override
+	public Class<? extends Player> getCraftPlayerClass() {
+		return CraftPlayer.class;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -20,7 +20,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import dev.jorel.commandapi.SafeVarHandle;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -97,6 +99,8 @@ import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria.RenderType;
 
 public class MockNMS extends Enums {
+	private static final SafeVarHandle<HelpMapMock, Map<String, HelpTopic>> helpMapTopics =
+		SafeVarHandle.ofOrNull(HelpMapMock.class, "topics", "topics", Map.class);
 
 	static {
 		CodeSource src = PotionEffectType.class.getProtectionDomain().getCodeSource();
@@ -615,4 +619,8 @@ public class MockNMS extends Enums {
 		return baseNMS.generateHelpTopic(commandName, shortDescription, fullDescription, permission);
 	}
 
+	@Override
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.SafeVarHandle;
 import net.minecraft.commands.Commands;
@@ -279,6 +280,11 @@ public class MockNMS extends Enums {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return baseNMS.wrapToVanillaCommandWrapper(node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@SuppressWarnings({ "deprecation", "unchecked" })

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
@@ -64,10 +64,10 @@ import net.minecraft.resources.ResourceKey;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public abstract class ArgumentNMS extends MockPlatform<CommandSourceStack> {
 
-	CommandAPIBukkit<?> baseNMS;
+	CommandAPIBukkit<CommandSourceStack> baseNMS;
 
 	protected ArgumentNMS(CommandAPIBukkit<?> baseNMS) {
-		this.baseNMS = baseNMS;
+		this.baseNMS = (CommandAPIBukkit<CommandSourceStack>) baseNMS;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -20,7 +20,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import dev.jorel.commandapi.SafeVarHandle;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -95,6 +97,8 @@ import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria.RenderType;
 
 public class MockNMS extends Enums {
+	private static final SafeVarHandle<HelpMapMock, Map<String, HelpTopic>> helpMapTopics =
+		SafeVarHandle.ofOrNull(HelpMapMock.class, "topics", "topics", Map.class);
 
 	static {
 		CodeSource src = PotionEffectType.class.getProtectionDomain().getCodeSource();
@@ -796,4 +800,8 @@ public class MockNMS extends Enums {
 		return baseNMS.generateHelpTopic(commandName, shortDescription, fullDescription, permission);
 	}
 
+	@Override
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.SafeVarHandle;
 import net.minecraft.commands.Commands;
@@ -275,6 +276,11 @@ public class MockNMS extends Enums {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return baseNMS.wrapToVanillaCommandWrapper(node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@SuppressWarnings({ "deprecation", "unchecked" })

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
@@ -71,10 +71,10 @@ import net.minecraft.resources.ResourceKey;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public abstract class ArgumentNMS extends MockPlatform<CommandSourceStack> {
 
-	CommandAPIBukkit<?> baseNMS;
+	CommandAPIBukkit<CommandSourceStack> baseNMS;
 
 	protected ArgumentNMS(CommandAPIBukkit<?> baseNMS) {
-		this.baseNMS = baseNMS;
+		this.baseNMS = (CommandAPIBukkit<CommandSourceStack>) baseNMS;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.SafeVarHandle;
 import net.minecraft.commands.Commands;
@@ -276,6 +277,11 @@ public class MockNMS extends Enums {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return baseNMS.wrapToVanillaCommandWrapper(node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@SuppressWarnings({ "deprecation", "unchecked" })

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -20,12 +20,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.World;
+import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_19_R3.CraftParticle;
@@ -115,7 +117,7 @@ public class MockNMS extends Enums {
 		super(baseNMS);
 
 		// Stub in our getMinecraftServer implementation
-		CommandAPIBukkit<?> nms = Mockito.spy(super.baseNMS);
+		CommandAPIBukkit<CommandSourceStack> nms = Mockito.spy(super.baseNMS);
 		Mockito.when(nms.getMinecraftServer()).thenAnswer(i -> getMinecraftServer());
 		super.baseNMS = nms;
 
@@ -142,6 +144,18 @@ public class MockNMS extends Enums {
 		this.recipeManager = new RecipeManager();
 		this.functions = new HashMap<>();
 		registerDefaultRecipes();
+
+		// Setup playerListMock
+		playerListMock = Mockito.mock(PlayerList.class);
+		Mockito.when(playerListMock.getPlayerByName(anyString())).thenAnswer(invocation -> {
+			String playerName = invocation.getArgument(0);
+			for (ServerPlayer onlinePlayer : players) {
+				if (onlinePlayer.getBukkitEntity().getName().equals(playerName)) {
+					return onlinePlayer;
+				}
+			}
+			return null;
+		});
 	}
 
 	/*************************
@@ -258,6 +272,16 @@ public class MockNMS extends Enums {
 		return ((ServerMock) Bukkit.getServer()).getCommandMap();
 	}
 
+	@Override
+	public boolean isVanillaCommandWrapper(Command command) {
+		return baseNMS.isVanillaCommandWrapper(command);
+	}
+
+	@Override
+	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
+		return baseNMS.wrapToVanillaCommandWrapper(node);
+	}
+
 	@SuppressWarnings({ "deprecation", "unchecked" })
 	@Override
 	public CommandSourceStack getBrigadierSourceFromCommandSender(AbstractCommandSender<? extends CommandSender> senderWrapper) {
@@ -290,19 +314,6 @@ public class MockNMS extends Enums {
 																																					// AdventureChatArgument
 				Mockito.when(entityPlayerMock.getType()).thenReturn((net.minecraft.world.entity.EntityType) net.minecraft.world.entity.EntityType.PLAYER); // EntitySelectorArgument
 				players.add(entityPlayerMock);
-			}
-
-			if (playerListMock == null) {
-				playerListMock = Mockito.mock(PlayerList.class);
-				Mockito.when(playerListMock.getPlayerByName(anyString())).thenAnswer(invocation -> {
-					String playerName = invocation.getArgument(0);
-					for (ServerPlayer onlinePlayer : players) {
-						if (onlinePlayer.getBukkitEntity().getName().equals(playerName)) {
-							return onlinePlayer;
-						}
-					}
-					return null;
-				});
 			}
 
 			// CommandSourceStack#levels

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -20,7 +20,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import dev.jorel.commandapi.SafeVarHandle;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -96,6 +98,8 @@ import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria.RenderType;
 
 public class MockNMS extends Enums {
+	private static final SafeVarHandle<HelpMapMock, Map<String, HelpTopic>> helpMapTopics =
+		SafeVarHandle.ofOrNull(HelpMapMock.class, "topics", "topics", Map.class);
 
 	static {
 		CodeSource src = PotionEffectType.class.getProtectionDomain().getCodeSource();
@@ -807,4 +811,8 @@ public class MockNMS extends Enums {
 		return baseNMS.generateHelpTopic(commandName, shortDescription, fullDescription, permission);
 	}
 
+	@Override
+	public Map<String, HelpTopic> getHelpMap() {
+		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -7,22 +7,14 @@ import static org.mockito.ArgumentMatchers.anyString;
 import java.io.File;
 import java.io.IOException;
 import java.security.CodeSource;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.SafeVarHandle;
+import net.minecraft.commands.Commands;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -311,11 +303,15 @@ public class MockNMS extends Enums {
 			for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
 				ServerPlayer entityPlayerMock = Mockito.mock(ServerPlayer.class);
 				CraftPlayer craftPlayerMock = Mockito.mock(CraftPlayer.class);
-				Mockito.when(craftPlayerMock.getName()).thenReturn(onlinePlayer.getName());
-				Mockito.when(craftPlayerMock.getUniqueId()).thenReturn(onlinePlayer.getUniqueId());
+
+				// Extract these variables first in case the onlinePlayer is a Mockito object itself
+				String name = onlinePlayer.getName();
+				UUID uuid = onlinePlayer.getUniqueId();
+
+				Mockito.when(craftPlayerMock.getName()).thenReturn(name);
+				Mockito.when(craftPlayerMock.getUniqueId()).thenReturn(uuid);
 				Mockito.when(entityPlayerMock.getBukkitEntity()).thenReturn(craftPlayerMock);
-				Mockito.when(entityPlayerMock.getDisplayName()).thenReturn(net.minecraft.network.chat.Component.literal(onlinePlayer.getName())); // ChatArgument,
-																																					// AdventureChatArgument
+				Mockito.when(entityPlayerMock.getDisplayName()).thenReturn(net.minecraft.network.chat.Component.literal(name)); // ChatArgument, AdventureChatArgument
 				Mockito.when(entityPlayerMock.getType()).thenReturn((net.minecraft.world.entity.EntityType) net.minecraft.world.entity.EntityType.PLAYER); // EntitySelectorArgument
 				players.add(entityPlayerMock);
 			}
@@ -536,6 +532,11 @@ public class MockNMS extends Enums {
 		Mockito.when(minecraftServerMock.getGameRules()).thenAnswer(i -> new GameRules());
 		Mockito.when(minecraftServerMock.getProfiler()).thenAnswer(i -> InactiveMetricsRecorder.INSTANCE.getProfiler());
 
+		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
+		Commands commands = new Commands();
+		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
+		minecraftServerMock.vanillaCommandDispatcher = commands;
+
 		return (T) minecraftServerMock;
 	}
 
@@ -569,6 +570,11 @@ public class MockNMS extends Enums {
 			tagFunctions.add(CommandFunction.fromLines(resourceLocation, Brigadier.getCommandDispatcher(), css, functionCommands));
 		}
 		this.tags.put(resourceLocation, tagFunctions);
+	}
+
+	@Override
+	public Class<? extends Player> getCraftPlayerClass() {
+		return CraftPlayer.class;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/src/main/java/dev/jorel/commandapi/test/ArgumentNMS.java
@@ -71,10 +71,10 @@ import net.minecraft.resources.ResourceKey;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public abstract class ArgumentNMS extends MockPlatform<CommandSourceStack> {
 
-	CommandAPIBukkit<?> baseNMS;
+	CommandAPIBukkit<CommandSourceStack> baseNMS;
 
 	protected ArgumentNMS(CommandAPIBukkit<?> baseNMS) {
-		this.baseNMS = baseNMS;
+		this.baseNMS = (CommandAPIBukkit<CommandSourceStack>) baseNMS;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -8,6 +8,7 @@ import be.seeseemelk.mockbukkit.potion.MockPotionEffectType;
 import com.google.common.collect.Streams;
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.jorel.commandapi.Brigadier;
 import dev.jorel.commandapi.CommandAPIBukkit;
@@ -260,6 +261,11 @@ public class MockNMS extends Enums {
 	@Override
 	public Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandSourceStack> node) {
 		return baseNMS.wrapToVanillaCommandWrapper(node);
+	}
+
+	@Override
+	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
+		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@SuppressWarnings({ "deprecation", "unchecked" })

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
@@ -8,13 +8,10 @@ import com.mojang.brigadier.context.ParsedArgument;
 import dev.jorel.commandapi.CommandAPIBukkit;
 import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
 import dev.jorel.commandapi.wrappers.ParticleData;
-import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.help.HelpTopic;
 import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffectType;
@@ -31,7 +28,6 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
-
 	/*****************
 	 * Instantiation *
 	 *****************/
@@ -81,18 +77,6 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 	@Override
 	public final BukkitCommandSender<? extends CommandSender> getSenderForCommand(CommandContext<CLW> cmdCtx, boolean forceNative) {
 		return getCommandSenderFromCommandSource(cmdCtx.getSource());
-	}
-
-	@Override
-	public final void addToHelpMap(Map<String, HelpTopic> helpTopicsToAdd) {
-		// We don't want to call the NMS implementation of addToHelpMap because
-		// that uses reflection to access SimpleHelpMap. Luckily for us, the
-		// HelpMapMock's addTopic implementation is exactly what we want! - it
-		// uses Map#put() with no restrictions, whereas SimpleHelpMap#addTopic
-		// only adds the help topic if the topic name doesn't already exist
-		for(HelpTopic topic : helpTopicsToAdd.values()) {
-			Bukkit.getServer().getHelpMap().addTopic(topic);
-		}
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
@@ -6,12 +6,14 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.ParsedArgument;
 import dev.jorel.commandapi.CommandAPIBukkit;
+import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
 import dev.jorel.commandapi.wrappers.ParticleData;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffectType;
@@ -109,8 +111,12 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 	 ******************/
 
 	public static Object getField(Class<?> className, String fieldName, Object instance) {
+		return getField(className, fieldName, fieldName, instance);
+	}
+
+	public static Object getField(Class<?> className, String fieldName, String mojangMappedName, Object instance) {
 		try {
-			Field field = className.getDeclaredField(fieldName);
+			Field field = className.getDeclaredField(SafeVarHandle.USING_MOJANG_MAPPINGS ? mojangMappedName : fieldName);
 			field.setAccessible(true);
 			return field.get(instance);
 		} catch (ReflectiveOperationException e) {
@@ -119,8 +125,12 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 	}
 
 	public static void setField(Class<?> className, String fieldName, Object instance, Object value) {
+		setField(className, fieldName, fieldName, instance, value);
+	}
+
+	public static void setField(Class<?> className, String fieldName, String mojangMappedName, Object instance, Object value) {
 		try {
-			Field field = className.getDeclaredField(fieldName);
+			Field field = className.getDeclaredField(SafeVarHandle.USING_MOJANG_MAPPINGS ? mojangMappedName : fieldName);
 			field.setAccessible(true);
 			field.set(instance, value);
 		} catch (ReflectiveOperationException e) {
@@ -129,8 +139,12 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 	}
 
 	public static <T> T getFieldAs(Class<?> className, String fieldName, Object instance, Class<T> asType) {
+		return getFieldAs(className, fieldName, fieldName, instance, asType);
+	}
+
+	public static <T> T getFieldAs(Class<?> className, String fieldName, String mojangMappedName, Object instance, Class<T> asType) {
 		try {
-			Field field = className.getDeclaredField(fieldName);
+			Field field = className.getDeclaredField(SafeVarHandle.USING_MOJANG_MAPPINGS ? mojangMappedName : fieldName);
 			field.setAccessible(true);
 			return asType.cast(field.get(instance));
 		} catch (ReflectiveOperationException e) {
@@ -154,6 +168,8 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 	
 	public abstract void addFunction(NamespacedKey key, List<String> commands);
 	public abstract void addTag(NamespacedKey key, List<List<String>> commands);
+
+	public abstract Class<? extends Player> getCraftPlayerClass();
 
 	/**
 	 * Converts 1.16.5 and below potion effect names to NamespacedKey names. For

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
@@ -1,5 +1,24 @@
 package dev.jorel.commandapi.test;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.context.ParsedArgument;
+import dev.jorel.commandapi.CommandAPIBukkit;
+import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
+import dev.jorel.commandapi.wrappers.ParticleData;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.help.HelpTopic;
+import org.bukkit.inventory.ItemFactory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffectType;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,28 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
-
-import org.bukkit.Bukkit;
-import org.bukkit.NamespacedKey;
-import org.bukkit.Particle;
-import org.bukkit.Sound;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.help.HelpTopic;
-import org.bukkit.inventory.ItemFactory;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.potion.PotionEffectType;
-
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.context.ParsedArgument;
-
-import dev.jorel.commandapi.CommandAPIBukkit;
-import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
-import dev.jorel.commandapi.wrappers.ParticleData;
 
 public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 
@@ -63,6 +60,7 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 	 ************************************/
 
 	private CommandDispatcher<CLW> dispatcher = null;
+	private CommandDispatcher<CLW> resourcesDispatcher = null;
 
 	@Override
 	public final CommandDispatcher<CLW> getBrigadierDispatcher() {
@@ -70,6 +68,14 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 			this.dispatcher = new CommandDispatcher<>();
 		}
 		return this.dispatcher;
+	}
+
+	@Override
+	public CommandDispatcher<CLW> getResourcesDispatcher() {
+		if (this.resourcesDispatcher == null) {
+			this.resourcesDispatcher = new CommandDispatcher<>();
+		}
+		return this.resourcesDispatcher;
 	}
 
 	@Override
@@ -106,11 +112,6 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 
 	@Override
 	public final String convert(Sound sound) {
-		throw new UnimplementedError();
-	}
-
-	@Override
-	public final boolean isVanillaCommandWrapper(Command command) {
 		throw new UnimplementedError();
 	}
 
@@ -152,7 +153,7 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 			return null;
 		}
 	}
-	
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public static <T> T forceGetArgument(CommandContext cmdCtx, String key) {
 		ParsedArgument result = (ParsedArgument) getFieldAs(CommandContext.class, "arguments", cmdCtx, Map.class).get(key);

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/CommandUnregisterTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/CommandUnregisterTests.java
@@ -1,0 +1,333 @@
+package dev.jorel.commandapi.test;
+
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import dev.jorel.commandapi.CommandAPI;
+import dev.jorel.commandapi.CommandAPIBukkit;
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.StringArgument;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandUnregisterTests extends TestBase {
+
+	/*********
+	 * Setup *
+	 *********/
+	static class BRIG_TREE {
+		static String FULL = """
+			{
+			  "type": "root",
+			  "children": {
+			    "minecraft:test": {
+			      "type": "literal",
+			      "children": {
+			        "string": {
+			          "type": "argument",
+			          "parser": "brigadier:string",
+			          "properties": {
+			            "type": "word"
+			          },
+			          "executable": true
+			        }
+			      }
+			    },
+			    "test": {
+			      "type": "literal",
+			      "children": {
+			        "string": {
+			          "type": "argument",
+			          "parser": "brigadier:string",
+			          "properties": {
+			            "type": "word"
+			          },
+			          "executable": true
+			        }
+			      }
+			    }
+			  }
+			}""";
+
+		static String NO_MAIN = """
+			{
+			  "type": "root",
+			  "children": {
+			    "minecraft:test": {
+			      "type": "literal",
+			      "children": {
+			        "string": {
+			          "type": "argument",
+			          "parser": "brigadier:string",
+			          "properties": {
+			            "type": "word"
+			          },
+			          "executable": true
+			        }
+			      }
+			    }
+			  }
+			}""";
+
+		static String NO_NAMESPACE = """
+			{
+			  "type": "root",
+			  "children": {
+			    "test": {
+			      "type": "literal",
+			      "children": {
+			        "string": {
+			          "type": "argument",
+			          "parser": "brigadier:string",
+			          "properties": {
+			            "type": "word"
+			          },
+			          "executable": true
+			        }
+			      }
+			    }
+			  }
+			}""";
+
+		static String EMPTY = """
+			{
+			  "type": "root"
+			}""";
+	}
+
+	PlayerMock player;
+	Mut<String> vanillaResults;
+	CommandMap commandMap;
+	Mut<String> bukkitResults;
+	Command bukkitCommand;
+
+	@BeforeEach
+	public void setUp() {
+		super.setUp();
+		disablePaperImplementations();
+
+		player = server.addPlayer();
+
+		// Set up a Vanilla command
+		vanillaResults = Mut.of();
+		new CommandAPICommand("test")
+			.withAliases("minecraft:test")
+			.withArguments(new StringArgument("string"))
+			.executes((sender, args) -> {
+				vanillaResults.set(args.getUnchecked(0));
+			})
+			.register();
+
+		assertEquals(BRIG_TREE.FULL, getDispatcherString());
+
+		assertStoresResult(player, "test word", vanillaResults, "word");
+		assertStoresResult(player, "minecraft:test word", vanillaResults, "word");
+
+		// Set up a Bukkit command
+		commandMap = CommandAPIBukkit.get().getSimpleCommandMap();
+
+		bukkitResults = Mut.of();
+		bukkitCommand = new Command("test") {
+			@Override
+			public boolean execute(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] arguments) {
+				if(arguments.length == 0) return false;
+				bukkitResults.set(arguments[0]);
+				return true;
+			}
+		};
+		commandMap.register("bukkit", bukkitCommand);
+
+		assertEquals(bukkitCommand, commandMap.getCommand("test"));
+		assertEquals(bukkitCommand, commandMap.getCommand("bukkit:test"));
+
+		assertStoresResult(player, "test word", bukkitResults, "word");
+		assertStoresResult(player, "bukkit:test word", bukkitResults, "word");
+
+
+		assertNoMoreResults(vanillaResults);
+		assertNoMoreResults(bukkitResults);
+
+		assertTrue(CommandAPI.canRegister());
+	}
+
+	@AfterEach
+	public void tearDown() {
+		super.tearDown();
+	}
+
+	/*********
+	 * Tests *
+	 *********/
+
+	@Test
+	void testUnregister() {
+		// unregisterNamespaces: false, unregisterBukkit: false
+		CommandAPI.unregister("test");
+
+		// Only minecraft:test left in the tree
+		assertEquals(BRIG_TREE.NO_MAIN, getDispatcherString());
+
+		// test goes to bukkit:test
+		assertStoresResult(player, "test word", bukkitResults, "word");
+		// minecraft:test passes
+		assertStoresResult(player, "minecraft:test word", vanillaResults, "word");
+
+
+		// Bukkit unchanged
+		assertEquals(bukkitCommand, commandMap.getCommand("test"));
+		assertEquals(bukkitCommand, commandMap.getCommand("bukkit:test"));
+
+		assertStoresResult(player, "test word", bukkitResults, "word");
+		assertStoresResult(player, "bukkit:test word", bukkitResults, "word");
+
+
+		assertNoMoreResults(vanillaResults);
+		assertNoMoreResults(bukkitResults);
+	}
+
+	@Test
+	void testUnregisterNamespace() {
+		// unregisterNamespaces: false, unregisterBukkit: false
+		CommandAPI.unregister("minecraft:test");
+
+		// Only test left in the tree
+		assertEquals(BRIG_TREE.NO_NAMESPACE, getDispatcherString());
+
+		// test goes to bukkit:test
+		assertStoresResult(player, "test word", bukkitResults, "word");
+		// minecraft:test fails
+		assertCommandFailsWith(player, "minecraft:test word",
+			"Unknown or incomplete command, see below for error at position 0: <--[HERE]");
+
+
+		// Bukkit unchanged
+		assertEquals(bukkitCommand, commandMap.getCommand("test"));
+		assertEquals(bukkitCommand, commandMap.getCommand("bukkit:test"));
+
+		// Both pass
+		assertStoresResult(player, "test word", bukkitResults, "word");
+		assertStoresResult(player, "bukkit:test word", bukkitResults, "word");
+
+
+		assertNoMoreResults(vanillaResults);
+		assertNoMoreResults(bukkitResults);
+	}
+
+	@Test
+	void testUnregisterBoth() {
+		// unregisterNamespaces: true, unregisterBukkit: false
+		CommandAPI.unregister("test", true);
+
+		// No test command in tree
+		assertEquals(BRIG_TREE.EMPTY, getDispatcherString());
+
+		// test goes to bukkit:test
+		assertStoresResult(player, "test word", bukkitResults, "word");
+		// minecraft:test fails
+		assertCommandFailsWith(player, "minecraft:test word",
+			"Unknown or incomplete command, see below for error at position 0: <--[HERE]");
+
+
+		// Bukkit unchanged
+		assertEquals(bukkitCommand, commandMap.getCommand("test"));
+		assertEquals(bukkitCommand, commandMap.getCommand("bukkit:test"));
+
+		// Both pass
+		assertStoresResult(player, "test word", bukkitResults, "word");
+		assertStoresResult(player, "bukkit:test word", bukkitResults, "word");
+
+
+		assertNoMoreResults(vanillaResults);
+		assertNoMoreResults(bukkitResults);
+	}
+
+	@Test
+	void testUnregisterBukkit() {
+		// unregisterNamespaces: false, unregisterBukkit: true
+		CommandAPIBukkit.unregister("test", false, true);
+
+		// Vanilla unchanged
+		assertEquals(BRIG_TREE.FULL, getDispatcherString());
+
+		// Both pass
+		assertStoresResult(player, "test word", vanillaResults, "word");
+		assertStoresResult(player, "minecraft:test word", vanillaResults, "word");
+
+
+		// Only bukkit:test left in the map
+		assertNull(commandMap.getCommand("test"));
+		assertEquals(bukkitCommand, commandMap.getCommand("bukkit:test"));
+
+		// test goes to minecraft:test
+		assertStoresResult(player, "test word", vanillaResults, "word");
+		// bukkit:test passes
+		assertStoresResult(player, "bukkit:test word", bukkitResults, "word");
+
+
+		assertNoMoreResults(vanillaResults);
+		assertNoMoreResults(bukkitResults);
+	}
+
+	@Test
+	void testUnregisterBukkitNamespace() {
+		// unregisterNamespaces: false, unregisterBukkit: true
+		CommandAPIBukkit.unregister("bukkit:test", false, true);
+
+		// Vanilla unchanged
+		assertEquals(BRIG_TREE.FULL, getDispatcherString());
+
+		// test goes to bukkit:test
+		assertStoresResult(player, "test word", bukkitResults, "word");
+		// minecraft:test passes
+		assertStoresResult(player, "minecraft:test word", vanillaResults, "word");
+
+
+		// Only test left in the map
+		assertEquals(bukkitCommand, commandMap.getCommand("test"));
+		assertNull(commandMap.getCommand("bukkit:test"));
+
+
+		// test passes
+		assertStoresResult(player, "test word", bukkitResults, "word");
+		// bukkit:test fails
+		assertCommandFailsWith(player, "bukkit:test word",
+			"Unknown or incomplete command, see below for error at position 0: <--[HERE]");
+
+
+		assertNoMoreResults(vanillaResults);
+		assertNoMoreResults(bukkitResults);
+	}
+
+	@Test
+	void testUnregisterBukkitBoth() {
+		// unregisterNamespaces: true, unregisterBukkit: true
+		CommandAPIBukkit.unregister("test", true, true);
+
+		// Vanilla unchanged
+		assertEquals(BRIG_TREE.FULL, getDispatcherString());
+
+		// Both pass
+		assertStoresResult(player, "test word", vanillaResults, "word");
+		assertStoresResult(player, "minecraft:test word", vanillaResults, "word");
+
+
+		// No test command in the map
+		assertNull(commandMap.getCommand("test"));
+		assertNull(commandMap.getCommand("bukkit:test"));
+
+		// test goes to minecraft:test
+		assertStoresResult(player, "test word", vanillaResults, "word");
+		// bukkit:test fails
+		assertCommandFailsWith(player, "bukkit:test word",
+			"Unknown or incomplete command, see below for error at position 0: <--[HERE]");
+
+
+		assertNoMoreResults(vanillaResults);
+		assertNoMoreResults(bukkitResults);
+	}
+}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
@@ -276,7 +276,7 @@ class OnEnableTests extends TestBase {
 		// You would expect namespace to succeed since it is in the CommandMap
 		// However, running that command simply tells the Brig dispatcher to run the original command
 		// The command was removed from the Brig dispacter, so it doesn't actually know how to do that
-		// I'm going to say this is not a bug, just an example why you should be careful when unregistering commands
+		// This behavior is documented at the bottom of the docs page for Command unregistration
 		// As a result, this test doesn't actually pass
 //		// Namespace command should still work
 //		assertStoresResult(runCommandsPlayer, "minecraft:command argument", results, "argument");

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
@@ -205,7 +205,7 @@ class OnEnableTests extends TestBase {
 		assertStoresResult(runCommandsPlayer, "minecraft:alias2 argument", results, "argument");
 
 
-		// Unregister main command without force
+		// Unregister just the main command
 		CommandAPI.unregister("command");
 
 		// Update commands should have been called for all players on the server
@@ -249,7 +249,7 @@ class OnEnableTests extends TestBase {
 		// Make sure command is removed from Bukkit CommandMap
 		assertNull(commandMap.getCommand("command"));
 
-		// Namespace should still be there since it wasn't forced
+		// Namespace should still be there
 		assertEquals(mainCommand, commandMap.getCommand("minecraft:command"));
 
 
@@ -267,19 +267,20 @@ class OnEnableTests extends TestBase {
 
 		// You would expect namespace to succeed since it is in the CommandMap
 		// However, running that command simply tells the Brig dispatcher to run the original command
-		// That command doesn't exist anymore, so it doesn't actually know how to run the command
-		// I'm going to say this is not a bug, just and example why you should be careful when unregistering commands
-//		// Namespace should still work since it wasn't forced
+		// The command was removed from the Brig dispacter, so it doesn't actually know how to do that
+		// I'm going to say this is not a bug, just an example why you should be careful when unregistering commands
+		// As a result, this test doesn't actually pass
+//		// Namespace command should still work
 //		assertStoresResult(runCommandsPlayer, "minecraft:command argument", results, "argument");
 
 
-		// Unregister main command with force
+		// Unregister the namespaced version of the command
 		CommandAPI.unregister("command", true);
 
 		// Update commands should have been called for all players on the server
 		Mockito.verify(updateCommandsPlayer, Mockito.times(3)).updateCommands();
 
-		// Namespace should be gone since force was used
+		// Namespace should be gone
 		assertNull(commandMap.getCommand("minecraft:command"));
 
 		// Namespace should fail

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
@@ -1,14 +1,19 @@
 package dev.jorel.commandapi.test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
+import com.mojang.brigadier.tree.RootCommandNode;
+import dev.jorel.commandapi.CommandAPI;
+import dev.jorel.commandapi.CommandAPIBukkit;
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.StringArgument;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.help.HelpTopic;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPICommand;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Run CommandAPI.onEnable()'s scheduler
@@ -43,14 +48,114 @@ class OnEnableTests extends TestBase {
 	void testOnEnableRegisterCommand() {
 		disablePaperImplementations();
 		assertDoesNotThrow(() -> server.getScheduler().performOneTick());
-		
+
 		assertFalse(CommandAPI.canRegister());
 
-		// Should log a warning
-		new CommandAPICommand("mycommand")
+		Mut<String> results = Mut.of();
+		new CommandAPICommand("command")
+			.withArguments(new StringArgument("argument"))
+			.withAliases("alias1", "alias2")
+			.withPermission("permission")
+			.withHelp("short description", "full description")
 			.executes((sender, args) -> {
+				results.set(args.getUnchecked(0));
 			})
 			.register();
-	}
 
+
+		// Make sure command tree built correctly
+		assertEquals("""
+			{
+			  "type": "root",
+			  "children": {
+			    "alias1": {
+			      "type": "literal",
+			      "children": {
+			        "argument": {
+			          "type": "argument",
+			          "parser": "brigadier:string",
+			          "properties": {
+			            "type": "word"
+			          },
+			          "executable": true
+			        }
+			      }
+			    },
+			    "alias2": {
+			      "type": "literal",
+			      "children": {
+			        "argument": {
+			          "type": "argument",
+			          "parser": "brigadier:string",
+			          "properties": {
+			            "type": "word"
+			          },
+			          "executable": true
+			        }
+			      }
+			    },
+			    "command": {
+			      "type": "literal",
+			      "children": {
+			        "argument": {
+			          "type": "argument",
+			          "parser": "brigadier:string",
+			          "properties": {
+			            "type": "word"
+			          },
+			          "executable": true
+			        }
+			      }
+			    }
+			  }
+			}""", getDispatcherString());
+
+		// Make sure command and its aliases exist in the Bukkit CommandMap as VanillaCommandWrappers
+		SimpleCommandMap commandMap = CommandAPIBukkit.get().getSimpleCommandMap();
+
+		Command mainCommand = commandMap.getCommand("command");
+		assertNotNull(mainCommand);
+		assertTrue(CommandAPIBukkit.get().isVanillaCommandWrapper(mainCommand));
+
+		Command alias1Command = commandMap.getCommand("alias1");
+		assertNotNull(alias1Command);
+		assertTrue(CommandAPIBukkit.get().isVanillaCommandWrapper(alias1Command));
+
+		Command alias2Command = commandMap.getCommand("alias2");
+		assertNotNull(alias2Command);
+		assertTrue(CommandAPIBukkit.get().isVanillaCommandWrapper(alias2Command));
+
+		// Make sure namespaces were set up as well
+		assertEquals(mainCommand, commandMap.getCommand("minecraft:command"));
+		assertEquals(alias1Command, commandMap.getCommand("minecraft:alias1"));
+		assertEquals(alias2Command, commandMap.getCommand("minecraft:alias2"));
+
+		// Make sure permissions were added to Bukkit commands
+		assertEquals("permission", mainCommand.getPermission());
+		assertEquals("permission", alias1Command.getPermission());
+		assertEquals("permission", alias2Command.getPermission());
+
+
+		// Make sure commands were added to 'resources' dispatcher
+		RootCommandNode<?> root = CommandAPIBukkit.get().getResourcesDispatcher().getRoot();
+
+		assertNotNull(root.getChild("command"));
+		assertNotNull(root.getChild("alias1"));
+		assertNotNull(root.getChild("alias2"));
+
+
+		// Check the help topic was added
+		HelpTopic topic = server.getHelpMap().getHelpTopic("/command");
+		assertNotNull(topic);
+
+		// Check the short description
+		assertEquals("short description", topic.getShortText());
+
+		// Check the full description
+		assertEquals(ChatColor.translateAlternateColorCodes('&', """
+			short description
+			&6Description: &ffull description
+			&6Usage: &f/command <argument>
+			&6Aliases: &falias1, alias2"""), topic.getFullText(null));
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
@@ -180,6 +180,11 @@ class OnEnableTests extends TestBase {
 		assertNotNull(resourcesRoot.getChild("alias1"));
 		assertNotNull(resourcesRoot.getChild("alias2"));
 
+		// Namespaces should be in the resources dispatcher too
+		assertNotNull(resourcesRoot.getChild("minecraft:command"));
+		assertNotNull(resourcesRoot.getChild("minecraft:alias1"));
+		assertNotNull(resourcesRoot.getChild("minecraft:alias2"));
+
 
 		// Check the help topic was added
 		HelpTopic topic = server.getHelpMap().getHelpTopic("/command");
@@ -256,6 +261,9 @@ class OnEnableTests extends TestBase {
 		// Command should be removed from resources dispatcher
 		assertNull(resourcesRoot.getChild("command"));
 
+		// Namespace should still be there
+		assertNotNull(resourcesRoot.getChild("minecraft:command"));
+
 
 		// Help topic should be gone
 		assertNull(server.getHelpMap().getHelpTopic("/command"));
@@ -280,8 +288,11 @@ class OnEnableTests extends TestBase {
 		// Update commands should have been called for all players on the server
 		Mockito.verify(updateCommandsPlayer, Mockito.times(3)).updateCommands();
 
-		// Namespace should be gone
+		// Namespace should be gone from Bukkit's map
 		assertNull(commandMap.getCommand("minecraft:command"));
+
+		// Namespace should be gone from resources dispatcher
+		assertNull(resourcesRoot.getChild("minecraft:command"));
 
 		// Namespace should fail
 		assertCommandFailsWith(runCommandsPlayer, "minecraft:command argument",

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/TestBase.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/TestBase.java
@@ -106,7 +106,9 @@ public abstract class TestBase {
 		assertDoesNotThrow(() -> assertTrue(
 			server.dispatchThrowableCommand(sender, command),
 			"Expected command dispatch to return true, but it gave false"));
-		assertEquals(expected, queue.get());
+		assertEquals(expected,
+			assertDoesNotThrow(queue::get, "Expected to find <" + expected + "> in queue, but nothing was present")
+		);
 	}
 
 	@Deprecated

--- a/commandapi-platforms/commandapi-sponge/commandapi-sponge-core/src/main/java/dev/jorel/commandapi/CommandAPISponge.java
+++ b/commandapi-platforms/commandapi-sponge/commandapi-sponge-core/src/main/java/dev/jorel/commandapi/CommandAPISponge.java
@@ -72,7 +72,7 @@ public class CommandAPISponge extends CommandAPIPlatform<Argument<?>, Object, Ob
 	}
 
 	@Override
-	public void unregister(String commandName, boolean force) {
+	public void unregister(String commandName, boolean unregisterNamespaces) {
 //		commandManager.unregister(commandName);
 	}
 

--- a/commandapi-platforms/commandapi-sponge/commandapi-sponge-core/src/main/java/dev/jorel/commandapi/CommandAPISponge.java
+++ b/commandapi-platforms/commandapi-sponge/commandapi-sponge-core/src/main/java/dev/jorel/commandapi/CommandAPISponge.java
@@ -124,7 +124,7 @@ public class CommandAPISponge extends CommandAPIPlatform<Argument<?>, Object, Ob
 	}
 
 	@Override
-	public void postCommandRegistration(LiteralCommandNode<Object> resultantNode, List<LiteralCommandNode<Object>> aliasNodes) {
+	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Object> resultantNode, List<LiteralCommandNode<Object>> aliasNodes) {
 		// Nothing to do?
 	}
 

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVelocity.java
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVelocity.java
@@ -210,7 +210,7 @@ public class CommandAPIVelocity implements CommandAPIPlatform<Argument<?>, Comma
 	}
 
 	@Override
-	public void postCommandRegistration(LiteralCommandNode<CommandSource> resultantNode, List<LiteralCommandNode<CommandSource>> aliasNodes) {
+	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<CommandSource> resultantNode, List<LiteralCommandNode<CommandSource>> aliasNodes) {
 		// Nothing to do
 	}
 

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVelocity.java
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVelocity.java
@@ -104,7 +104,7 @@ public class CommandAPIVelocity implements CommandAPIPlatform<Argument<?>, Comma
 	}
 
 	@Override
-	public void unregister(String commandName, boolean force) {
+	public void unregister(String commandName, boolean unregisterNamespaces) {
 		commandManager.unregister(commandName);
 	}
 

--- a/docssrc/src/SUMMARY.md
+++ b/docssrc/src/SUMMARY.md
@@ -25,6 +25,7 @@
 # Creating Commands
 
 - [Command registration](./commandregistration.md)
+- [Command unregistration](./commandunregistration.md)
 - [Command executors](./commandexecutors.md)
   - [Normal command executors](./normalexecutors.md)
   - [Proxied commandsenders](./proxysender.md)

--- a/docssrc/src/commandregistration.md
+++ b/docssrc/src/commandregistration.md
@@ -176,12 +176,14 @@ Registers the command.
 
 ## Command loading order
 
-In order to register commands properly, **commands must be registered before the server finishes loading**. The CommandAPI will output a warning if you register a command after the server has loaded. This means that all command registration must occur during a plugin's `onLoad()` or `onEnable()` method. With the CommandAPI, depending on whether you use `onLoad()` or `onEnable()` to load your commands depends on whether your plugin is used with Minecraft's functions:
+It is recommended to register commands in either the `onLoad()` or `onEnable()` method. With the CommandAPI, depending on whether you use `onLoad()` or `onEnable()` to load your commands depends on whether your plugin is used with Minecraft's functions:
 
 | When to load        | What to do                                                                                                     |
 | ------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `onLoad()` method   | Register commands to be used in Minecraft functions ([see the Function section for more info](functions.html)) |
 | `onEnable()` method | Register regular commands                                                                                      |
+
+The CommandAPI does support registering commands outside of these methods while the server is running. Commands registered after the server is done loading *should* work the same as commands registered in `onEnable`.
 
 -----
 

--- a/docssrc/src/commandregistration.md
+++ b/docssrc/src/commandregistration.md
@@ -183,7 +183,7 @@ It is recommended to register commands in either the `onLoad()` or `onEnable()` 
 | `onLoad()` method   | Register commands to be used in Minecraft functions ([see the Function section for more info](functions.html)) |
 | `onEnable()` method | Register regular commands                                                                                      |
 
-The CommandAPI does support registering commands outside of these methods while the server is running. Commands registered after the server is done loading *should* work the same as commands registered in `onEnable`.
+The CommandAPI does support registering commands outside of these methods while the server is running. Commands registered after the server is done loading _should_ work the same as commands registered in `onEnable`.
 
 -----
 

--- a/docssrc/src/commandregistration.md
+++ b/docssrc/src/commandregistration.md
@@ -179,49 +179,8 @@ Registers the command.
 It is recommended to register commands in either the `onLoad()` or `onEnable()` method. With the CommandAPI, depending on whether you use `onLoad()` or `onEnable()` to load your commands depends on whether your plugin is used with Minecraft's functions:
 
 | When to load        | What to do                                                                                                     |
-| ------------------- | -------------------------------------------------------------------------------------------------------------- |
+|---------------------|----------------------------------------------------------------------------------------------------------------|
 | `onLoad()` method   | Register commands to be used in Minecraft functions ([see the Function section for more info](functions.html)) |
 | `onEnable()` method | Register regular commands                                                                                      |
 
 The CommandAPI does support registering commands outside of these methods while the server is running. Commands registered after the server is done loading _should_ work the same as commands registered in `onEnable`.
-
------
-
-## Command unregistration
-
-The CommandAPI has support to unregister commands completely from Minecraft's command list. This includes Minecraft built in commands!
-
-<div class="warning">
-
-**Developer's Note:**
-
-Command unregistration, although powerful, is not recommended! It is the CommandAPI's most "dangerous" feature as it can cause unexpected side effects, such as command blocks executing commands you wouldn't expect them to. In almost every case, I'd recommend just creating a new command instead of unregistering one to replace it.
-
-For instance, instead of unregistering `/gamemode`, you could register a command `/gm` or `/changegamemode`.
-
-</div>
-
-| Method                                             | Result                                                       |
-| -------------------------------------------------- | ------------------------------------------------------------ |
-| `CommandAPI.unregister(String cmd)`                | Unregisters a command from the game                          |
-| `CommandAPI.unregister(String cmd, boolean force)` | Attempts to unregister a command from the game by force. This includes `/minecraft:cmd`, `/bukkit:cmd` and `/spigot:cmd` commands as well. |
-
-<div class="example">
-
-### Example - Replacing Minecraft's `/gamemode` command
-
-To replace a command, we can first unregister it and then register our implementation of that command.
-
-<div class="multi-pre">
-
-```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandRegistration2}}
-```
-
-```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandRegistration2}}
-```
-
-</div>
-
-</div>

--- a/docssrc/src/commandunregistration.md
+++ b/docssrc/src/commandunregistration.md
@@ -6,7 +6,7 @@ There are three methods you might use when unregistering commands:
 
 ```java
 CommandAPI.unregister(String commandName);
-CommandAPI.unregister(String commandName, boolean unreigsterNamespaces);
+CommandAPI.unregister(String commandName, boolean unregisterNamespaces);
 CommandAPIBukkit.unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit);
 ```
 
@@ -36,13 +36,13 @@ CommandAPI.unregister(String commandName);
 Unregisters a command from the Vanilla CommandDispatcher.
 
 ```java
-CommandAPI.unreigster(String commandName, boolean unreigsterNamespaces);
+CommandAPI.unregister(String commandName, boolean unregisterNamespaces);
 ```
 
 Unregisters a command from the Vanilla CommandDispatcher. If `unregisterNamespaces` is `true`, then any namespaced version of the command is also unregistered.
 
 ```java
-CommandAPIBukkit.unregister(String commandName, boolean unregisterNamespaces, boolean unreigsterBukkit);
+CommandAPIBukkit.unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit);
 ```
 
 Unregisters a command from Bukkit. As before, if `unregisterNamespaces` is `true`, then any namespaced version of the command is also unregistered. If `unregisterBukkit` is `true`, then only Bukkit commands in the Bukkit CommandMap are unregistered. If `unregisterBukkit` is `false`, only commands from the Vanilla CommandDispatcher are unregistered.
@@ -67,13 +67,13 @@ Since this command exists in the Bukkit CommandMap, we'll need to use `CommandAP
 
 </div>
 
-With this plugin, executing `/version` or `/bukkit:version` will give the unknown command message. Note that aliases like `/ver` and its namespaced version `/bukkit:ver` will still work. To remove aliases as well, you need to unregister each as its own command. For, `/ver`, that would mean calling `CommandAPIBukkit.unreigster("ver", true, true)`.
+With this plugin, executing `/version` or `/bukkit:version` will give the unknown command message. Note that aliases like `/ver` and its namespaced version `/bukkit:ver` will still work. To remove aliases as well, you need to unregister each as its own command. For, `/ver`, that would mean calling `CommandAPIBukkit.unregister("ver", true, true)`.
 
 ## Unregistering a Vanilla command - `/gamemode`
 
 `/gamemode` is a command provided by Vanilla Minecraft. Like the [previous example](#unregistering-a-bukkit-command---version), Vanilla commands are created in step 1, before plugins are loaded in step 3. For variety, we'll unregister the command in our plugin's `onEnable` -- step 4 -- but the same code would also work in `onLoad`.
 
-Since this command exists in the Vanilla CommandDispatcher, we can use `CommandAPI#unregister`. That works the same as `CommandAPIBukkit#unregister` with `unregisterBukkit` set to `false`. We don't care about the namespace, so `unregisterNamespaces` will be `false`. That means we can use the simplest method, `CommandAPI.unreigster(String commandName)`, since it sets `unregisterNamespaces` to `false` by default. All together, the code looks like this:
+Since this command exists in the Vanilla CommandDispatcher, we can use `CommandAPI#unregister`. That works the same as `CommandAPIBukkit#unregister` with `unregisterBukkit` set to `false`. We don't care about the namespace, so `unregisterNamespaces` will be `false`. That means we can use the simplest method, `CommandAPI.unregister(String commandName)`, since it sets `unregisterNamespaces` to `false` by default. All together, the code looks like this:
 
 <div class="multi-pre">
 
@@ -255,7 +255,7 @@ Doing the opposite action here -- only unregistering `/gamemode` but keeping `/m
 
 The expected outcome of this code is that `/minecraft:gamemode` would work as expected, and `/gamemode` would give the command not found message. However, that is only true for the player's commands. If you try to use `/minecraft:gamemode` in the console, it *will not work* properly. Specifically, while you can tab-complete the command's label, `minecraft:gamemode` the command's arguments will not have any suggestions. If you try to execute `/minecraft:gamemode` in the console, it will always tell you your command is unknown or incomplete.
 
-The main point is that if you ever try to unregister a Vanilla command after the server is enabled, the namespaced version of that command will break for the console. To avoid this issue, always set `unreigsterNamespaces` to `true` if `unreigsterBukkit` is `false` when unregistering commands after the server is enabled.
+The main point is that if you ever try to unregister a Vanilla command after the server is enabled, the namespaced version of that command will break for the console. To avoid this issue, always set `unregisterNamespaces` to `true` if `unregisterBukkit` is `false` when unregistering commands after the server is enabled.
 
 <div class="multi-pre">
 

--- a/docssrc/src/commandunregistration.md
+++ b/docssrc/src/commandunregistration.md
@@ -1,0 +1,272 @@
+# Command unregistration
+
+The CommandAPI allows you to remove commands completely from Minecraft's command list. This includes Vanilla commands, Bukkit commands, and plugin commands.
+
+There are three methods you might use when unregistering commands:
+
+```java
+CommandAPI.unregister(String commandName);
+CommandAPI.unregister(String commandName, boolean unreigsterNamespaces);
+CommandAPIBukkit.unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit);
+```
+
+To understand when and how to use these methods, you need to know a little about how Bukkit loads and sets up commands. This is basically the order of events when a Bukkit server starts:
+
+1. Vanilla commands are placed in the Vanilla CommandDispatcher
+2. Bukkit commands are placed in the Bukkit CommandMap
+   - Given the `bukkit` namespace (E.g. `bukkit:version`)
+3. Plugins are loaded
+   - `onLoad` is called
+4. Plugins are enabled
+   - Plugin commands are read from the [`plugin.yml` file](https://www.spigotmc.org/wiki/plugin-yml/#commands) and placed in the Bukkit CommandMap
+   - Given the plugin's name as their namespace (E.g. `luckperms:lp`)
+   - `onEnable` is called
+   - Repeat for each plugin
+5. Bukkit's help command is registered
+6. Vanilla commands are added to the Bukkit CommandMap
+   - Given the `minecraft` namespace (E.g. `minecraft:gamemode`)
+7. The server is done loading
+
+Unregistering a command only works if it happens after the command is created. Bukkit's command system is special and has two locations where commands can exist -- either the Vanilla CommandDispatcher or the Bukkit CommandMap -- so you also need to know where your command is registered. With that in mind, here is what each of the `unregister` methods do:
+
+```java
+CommandAPI.unregister(String commandName);
+```
+
+Unregisters a command from the Vanilla CommandDispatcher.
+
+```java
+CommandAPI.unreigster(String commandName, boolean unreigsterNamespaces);
+```
+
+Unregisters a command from the Vanilla CommandDispatcher. If `unregisterNamespaces` is `true`, then any namespaced version of the command is also unregistered.
+
+```java
+CommandAPIBukkit.unregister(String commandName, boolean unregisterNamespaces, boolean unreigsterBukkit);
+```
+
+Unregisters a command from Bukkit. As before, if `unregisterNamespaces` is `true`, then any namespaced version of the command is also unregistered. If `unregisterBukkit` is `true`, then only Bukkit commands in the Bukkit CommandMap are unregistered. If `unregisterBukkit` is `false`, only commands from the Vanilla CommandDispatcher are unregistered.
+
+To give a better idea of how and when to use these methods, the rest of this page documents how to unregister different types of commands.
+
+## Unregistering a Bukkit command - `/version`
+
+`/version` is a command provided by Bukkit. Looking at the sequence of events above, that means it is created during step 2, before plugins are loaded in step 3. Consequently, the command will exist when our plugin's `onLoad` method is called, so we'll unregister it there. The same code will work in `onEnable` too, since step 4 is also after step 2.
+
+Since this command exists in the Bukkit CommandMap, we'll need to use `CommandAPIBukkit#unregister` with `unregisterBukkit` set to `true`. We'll also remove the namespaced version -- `/bukkit:version` -- so `unregisterNamespaces` will be `true`. All together, the code looks like this:
+
+<div class="multi-pre">
+
+```java,Java
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationBukkit}}
+```
+
+```kotlin,Kotlin
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationBukkit}}
+```
+
+</div>
+
+With this plugin, executing `/version` or `/bukkit:version` will give the unknown command message. Note that aliases like `/ver` and its namespaced version `/bukkit:ver` will still work. To remove aliases as well, you need to unregister each as its own command. For, `/ver`, that would mean calling `CommandAPIBukkit.unreigster("ver", true, true)`.
+
+## Unregistering a Vanilla command - `/gamemode`
+
+`/gamemode` is a command provided by Vanilla Minecraft. Like the [previous example](#unregistering-a-bukkit-command---version), Vanilla commands are created in step 1, before plugins are loaded in step 3. For variety, we'll unregister the command in our plugin's `onEnable` -- step 4 -- but the same code would also work in `onLoad`.
+
+Since this command exists in the Vanilla CommandDispatcher, we can use `CommandAPI#unregister`. That works the same as `CommandAPIBukkit#unregister` with `unregisterBukkit` set to `false`. We don't care about the namespace, so `unregisterNamespaces` will be `false`. That means we can use the simplest method, `CommandAPI.unreigster(String commandName)`, since it sets `unregisterNamespaces` to `false` by default. All together, the code looks like this:
+
+<div class="multi-pre">
+
+```java,Java
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationVanilla}}
+```
+
+```kotlin,Kotlin
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationVanilla}}
+```
+
+</div>
+
+With this code, executing `/gamemode` will give the unknown command exception as expected. However, even though `unregisterNamespaces` was `false`, `/minecraft:gamemode` can also not be run. This happens because Vanilla commands are given their namespace in step 6, after our plugin has removed `/gamemode`.
+
+When the server starts, `/gamemode` is created in step 2 inside the Vanilla CommandDispatcher. In step 4, our plugin is enabled and we remove the `/gamemode` command from that CommandDispatcher. After all the plugins enable, step 6 moves all commands in the Vanilla CommandDispatcher to the Bukkit CommandMap and gives them the `minecraft` namespace. Since `/gamemode` doesn't exist at this point, step 6 cannot create the `/minecraft:gamemode` command. So, even though `unregisterNamespaces` was `false`, `/minecraft:gamemode` doesn't exist anyway.
+
+<div class="example">
+
+### Example - Replacing Minecraft's `/gamemode` command
+
+To replace a command, first unregister the original command, then register a new implementation for that command.
+
+<div class="multi-pre">
+
+```java,Java
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationReplaceVanilla}}
+```
+
+```kotlin,Kotlin
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationReplaceVanilla}}
+```
+
+</div>
+
+Now, when `/gamemode` is executed, it will use the new implementation defined using the CommandAPI.
+
+</div>
+
+## Unregistering a Plugin command - `/luckperms:luckperms`
+
+The `/luckperms` command is provided by the Bukkit [LuckPerms](https://luckperms.net/) plugin. Plugin commands are created during step 4, immediately before calling the `onEnable` method of the respective plugin. In this case, unregistering the command in our own plugin's `onLoad` would not work, since the command wouldn't exist yet. We also have to make sure that our `onEnable` method is called after LuckPerm's. The best way to make sure that happens is to add LuckPerms as a `depend` or `softdepend` in our plugin's plugin.yml. You can read more about the different between `depend` and `softdepend` in [Spigot's documentation](https://www.spigotmc.org/wiki/plugin-yml/#optional-attributes), but that will look something like this:
+
+```yaml
+name: MyPlugin
+main: some.package.name.Main
+version: 1.0
+depend:
+  - LuckPerms
+```
+
+Since plugin commands are stored in the Bukkit CommandMap, we need to use `CommandAPIBukkit#unregister` with `unregisterBukkit` set to `true`. For demonstration’s sake, we only want to unregister the namespaced version -- `/luckperms:luckperms` -- and leave `/luckperms` alone. To do this, give `"luckperms:luckperms"` as the `commandName`, and set `unregisterNamespaces` to `false`. All together, the code looks like this:
+
+<div class="multi-pre">
+
+```java,Java
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationPlugin}}
+```
+
+```kotlin,Kotlin
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationPlugin}}
+```
+
+</div>
+
+Executing `/luckperms` will work as normal, but `/luckperms:luckperms` will give the unknown command message.
+
+## Unregistering a CommandAPI command
+
+Unregistering a command created by the CommandAPI is similar to both unregistering a Vanilla command and a plugin command. Like a Vanilla command, CommandAPI commands are stored in the Vanilla CommandDispatcher, so they should be unregistered with `unregisterBukkit` set to `false`. Like plugin commands, they may be created in `onEnable`, so you need to make sure your plugin is enabled after the plugin that adds the command.
+
+Unlike plugin commands, CommandAPI commands may be created in `onLoad`, as discussed in [Command loading order](./commandregistration.md#command-loading-order). That just means you may also be able to unregister the command in you own plugin's `onLoad`. As always, simply make sure you unregister a command after it is created, and it will be removed properly.
+
+For our example, let's say we want to unregister the `/break` command created by the [Bukkit Maven Example Project](https://github.com/JorelAli/CommandAPI/tree/master/examples/bukkit/maven) for the CommandAPI. If you look at that plugin's code, you can see that it registers the `/break` command in it's `onEnable` method. Therefore, we can unregister the command in our own plugin's `onEnable`, making sure that our plugin will enable second by adding ExamplePlugin as a [`depend` or `softdepend`](https://www.spigotmc.org/wiki/plugin-yml/#optional-attributes).
+
+```yaml
+name: MyPlugin
+main: some.package.name.Main
+version: 1.0
+depend:
+  - CommandAPI
+  - ExamplePlugin
+```
+
+> **Developer's Note:**
+>
+> If you can't find the code where a CommandAPI command is registered or just don't have access to the code of a plugin, you can still figure out when a command is registered. If you set [`verbose-outputs`](./config.md#verbose-outputs) to `true` in the CommandAPI's configuration, it will log command registration.
+>
+> For the ExamplePlugin, setting `verbose-outputs` to `true` gives this:
+>
+> ```
+> [Server thread/INFO]: [ExamplePlugin] Enabling ExamplePlugin v0.0.1
+> [Server thread/INFO]: [CommandAPI] Registering command /break block<LocationArgument>
+> [Server thread/INFO]: [CommandAPI] Registering command /myeffect target<PlayerArgument> potion<PotionEffectArgument>
+> [Server thread/INFO]: [CommandAPI] Registering command /nbt nbt<NBTCompoundArgument>
+> ```
+>
+> You can see that the ExamplePlugin registers its commands when `onEnable` is called.
+
+In summary, we will unregister the `/break` command in our plugin's `onEnable`. We added Example plugin to the `depend` list in our plugin.yml so that our `onEnable` method runs second. `unregisterNamespaces` and `unregisterBukkit` will be set to `false`, and those are the default values, so we can simply use `CommandAPI.unregister(String commandName)`. All together, the code looks like this:
+
+<div class="multi-pre">
+
+```java,Java
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationCommandAPI}}
+```
+
+```kotlin,Kotlin
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationCommandAPI}}
+```
+
+</div>
+
+Now, when you try to execute `/break`, you will just get the unknown command message as if it never existed.
+
+## Special case: Unregistering Bukkit's `/help`
+
+If you look at the sequence of events at the top of this page, you might notice that Bukkit's `/help` command gets its own place in step 5. Unlike the other [Bukkit commands](#unregistering-a-bukkit-command---version), `/help` is special and gets registered after plugins are loaded and enabled (don't ask, I don't know why :P). That means unregistering `/help` in `onLoad` or `onEnable` does not work, since the command doesn't exist yet.
+
+In order to run our unregister task after the server is enabled, we can use Bukkit's [Scheduler API](https://bukkit.fandom.com/wiki/Scheduler_Programming). There are many ways to set up and run a task, and this should work in whatever way you like. You can even give the task zero delay, since Bukkit only starts processing tasks after the server is enabled.
+
+Since `/help` is in the Bukkit CommandMap, we need to use `CommandAPIBukkit#unregister` with `unregisterBukkit` set to `true`. We'll leave `/bukkit:help` alone, so `unregisterNamespaces` will be `false`. All together, we can unregister Bukkit's `/help` command with this code:
+
+<div class="multi-pre">
+
+```java,Java
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationBukkitHelp}}
+```
+
+```kotlin,Kotlin
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationBukkitHelp}}
+```
+
+</div>
+
+Funnily, if you try to execute `/help`, the server will still tell you: `Unknown command. Type "/help" for help.`. Luckily, `unregisterNamespaces` was `false`, so you can still use `/bukkit:help` to figure out your problem.
+
+## Special case: Unregistering only `/minecraft:gamemode`
+
+In the earlier example for [Unregistering `/gamemode`](#unregistering-a-vanilla-command---gamemode), even though `unregisterNamespaces` was `false`, the `/minecraft:gamemode` command was also not executable. As explained up there, this happens because the namespaced version of commands in the Vanilla CommandDispatcher are not created until after plugins are loaded and enabled. Since we unregistered `/gamemode` in `onEnable`, when the time came for the server to transfer Vanilla commands into the Bukkit CommandMap, it didn't know to create the `minecraft:gamemode` command. Consequently, this means we cannot normally remove only the `/minecraft:gamemode` command without also unregistering `/gamemode`.
+
+Of course, it is still possible to only unregister `/minecraft:gamemode` and the namespaced versions of other Vanilla commands. As always, in order to unregister a command, you have to unregister after the command is created. So, we just need to unregister `/minecraft:gamemode` after the server is enabled. Like the [previous special case](#special-case-unregistering-bukkits-help), we can use Bukkit's [Scheduler API](https://bukkit.fandom.com/wiki/Scheduler_Programming) to run our unregister task after the server is enabled.
+
+While `/minecraft:gamemode` only exists in the Bukkit CommandMap, it is the namespaced version of the Vanilla `/gamemode` command, so it is considered a Vanilla command. That means `unregisterBukkit` should be `false`, which is what it defaults to when using `CommandAPI#unregister`. The CommandAPI understands that once the server is enabled Vanilla commands will have been copied to the CommandMap, so it will be able to find `/minecraft:gamemode`
+
+Finally, `unregisterNamespaces` should be `false`, and since that's the default value we don't have to include it. All together, the code looks like this:
+
+<div class="multi-pre">
+
+```java,Java
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationOnlyVanillaNamespace}}
+```
+
+```kotlin,Kotlin
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationOnlyVanillaNamespace}}
+```
+
+</div>
+
+With this code, `/gamemode` will execute as normal, but `/minecraft:gamemode` will give the unknown command message.
+
+<div class="warning">
+
+**Developer's Note:**
+
+Doing the opposite action here -- only unregistering `/gamemode` but keeping `/minecraft:gamemode` -- is not recommended. That would be the following code, where `commandName` is `"gamemode"` (or any command in the Vanilla CommandDispatcher), and `unregisterNamespaces` is `false`:
+
+<div class="multi-pre">
+
+```java,Java
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationDealyedVanillaBad}}
+```
+
+```kotlin,Kotlin
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationDealyedVanillaBad}}
+```
+
+</div>
+
+The expected outcome of this code is that `/minecraft:gamemode` would work as expected, and `/gamemode` would give the command not found message. However, that is only true for the player's commands. If you try to use `/minecraft:gamemode` in the console, it *will not work* properly. Specifically, while you can tab-complete the command's label, `minecraft:gamemode` the command's arguments will not have any suggestions. If you try to execute `/minecraft:gamemode` in the console, it will always tell you your command is unknown or incomplete.
+
+The main point is that if you ever try to unregister a Vanilla command after the server is enabled, the namespaced version of that command will break for the console. To avoid this issue, always set `unreigsterNamespaces` to `true` if `unreigsterBukkit` is `false` when unregistering commands after the server is enabled.
+
+<div class="multi-pre">
+
+```java,Java
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationDealyedVanillaBetter}}
+```
+
+```kotlin,Kotlin
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationDealyedVanillaBetter}}
+```
+
+</div>
+
+</div>

--- a/docssrc/src/commandunregistration.md
+++ b/docssrc/src/commandunregistration.md
@@ -164,7 +164,7 @@ depend:
 >
 > For the ExamplePlugin, setting `verbose-outputs` to `true` gives this:
 >
-> ```
+> ```log
 > [Server thread/INFO]: [ExamplePlugin] Enabling ExamplePlugin v0.0.1
 > [Server thread/INFO]: [CommandAPI] Registering command /break block<LocationArgument>
 > [Server thread/INFO]: [CommandAPI] Registering command /myeffect target<PlayerArgument> potion<PotionEffectArgument>

--- a/docssrc/src/commandunregistration.md
+++ b/docssrc/src/commandunregistration.md
@@ -58,11 +58,11 @@ Since this command exists in the Bukkit CommandMap, we'll need to use `CommandAP
 <div class="multi-pre">
 
 ```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationBukkit}}
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistration1}}
 ```
 
 ```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationBukkit}}
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistration1}}
 ```
 
 </div>
@@ -78,11 +78,11 @@ Since this command exists in the Vanilla CommandDispatcher, we can use `CommandA
 <div class="multi-pre">
 
 ```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationVanilla}}
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistration2}}
 ```
 
 ```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationVanilla}}
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistration2}}
 ```
 
 </div>
@@ -100,11 +100,11 @@ To replace a command, first unregister the original command, then register a new
 <div class="multi-pre">
 
 ```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationReplaceVanilla}}
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistration3}}
 ```
 
 ```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationReplaceVanilla}}
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistration3}}
 ```
 
 </div>
@@ -130,11 +130,11 @@ Since plugin commands are stored in the Bukkit CommandMap, we need to use `Comma
 <div class="multi-pre">
 
 ```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationPlugin}}
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistration4}}
 ```
 
 ```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationPlugin}}
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistration4}}
 ```
 
 </div>
@@ -178,11 +178,11 @@ In summary, we will unregister the `/break` command in our plugin's `onEnable`. 
 <div class="multi-pre">
 
 ```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationCommandAPI}}
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistration5}}
 ```
 
 ```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationCommandAPI}}
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistration5}}
 ```
 
 </div>
@@ -200,11 +200,11 @@ Since `/help` is in the Bukkit CommandMap, we need to use `CommandAPIBukkit#unre
 <div class="multi-pre">
 
 ```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationBukkitHelp}}
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistration6}}
 ```
 
 ```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationBukkitHelp}}
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistration6}}
 ```
 
 </div>
@@ -224,11 +224,11 @@ Finally, `unregisterNamespaces` should be `false`, and since that's the default 
 <div class="multi-pre">
 
 ```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationOnlyVanillaNamespace}}
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistration7}}
 ```
 
 ```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationOnlyVanillaNamespace}}
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistration7}}
 ```
 
 </div>
@@ -244,11 +244,11 @@ Doing the opposite action here -- only unregistering `/gamemode` but keeping `/m
 <div class="multi-pre">
 
 ```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationDealyedVanillaBad}}
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistration8}}
 ```
 
 ```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationDealyedVanillaBad}}
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistration8}}
 ```
 
 </div>
@@ -260,11 +260,11 @@ The main point is that if you ever try to unregister a Vanilla command after the
 <div class="multi-pre">
 
 ```java,Java
-{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistrationDealyedVanillaBetter}}
+{{#include ../../commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java:commandUnregistration9}}
 ```
 
 ```kotlin,Kotlin
-{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistrationDealyedVanillaBetter}}
+{{#include ../../commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt:commandUnregistration9}}
 ```
 
 </div>


### PR DESCRIPTION
This PR makes it possible to register commands while a Bukkit server is running. 

Previously, if a developer attempted to register a command while the server was running, there would be a little warning `Command /(command name) is being registered after the server had loaded. Undefined behavior ahead!`. Unfortunately, it would pretty much seem like nothing at all happened.

Usually, the CommandAPI can just put commands into the `MinecraftServer#vanillaCommandDispatcher` CommandDispatcher and be done. Behind the scenes, CraftServer would sync everything up, and the commands would work. However, that sync process usually only happens as the server is finishing up its load and enabling processes. In order to get commands registered during server runtime to work properly, those synchronization processes just need to happen again.

So, with this PR, `CommandAPIBukkit#postCommandRegistration` now looks like this:
```java
public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes) {
	if(!CommandAPI.canRegister()) {
		// Usually, when registering commands during server startup, we can just put our commands into the
		// `net.minecraft.server.MinecraftServer#vanillaCommandDispatcher" and leave it. As the server finishes setup,
		// it and the CommandAPI do some extra stuff to make everything work, and we move on.
		// So, if we want to register commands while the server is running, we need to do all that extra stuff, and
		// that is what this code does.
		// We could probably call all those methods to sync everything up, but in the spirit of avoiding side effects
		// and avoiding doing things twice for existing commands, this is a distilled version of those methods.

		CommandMap map = paper.getCommandMap();
		String permNode = unpackInternalPermissionNodeString(registeredCommand.permission());
		RootCommandNode<Source> root = getResourcesDispatcher().getRoot();

		// Wrapping Brigadier nodes into VanillaCommandWrappers and putting them in the CommandMap usually happens
		// in `CraftServer#setVanillaCommands`
		Command command = wrapToVanillaCommandWrapper(resultantNode);
		map.register("minecraft", command);

		// Adding permissions to these Commands usually happens in `CommandAPIBukkit#onEnable`
		command.setPermission(permNode);

		// Adding commands to the other (Why bukkit/spigot?!) dispatcher usually happens in `CraftServer#syncCommands`
		root.addChild(resultantNode);

		// Do the same for the aliases
		for(LiteralCommandNode<Source> node: aliasNodes) {
			command = wrapToVanillaCommandWrapper(node);
			map.register("minecraft", command);

			command.setPermission(permNode);

			root.addChild(node);
		}

		// Adding the command to the help map usually happens in `CommandAPIBukkit#onEnable`
		updateHelpForCommands(List.of(registeredCommand));

		// Sending command dispatcher packets usually happens when Players join the server
		for(Player p: Bukkit.getOnlinePlayers()) {
			resendPackets(p);
		}
	}
}
```

If the server has finished loading (indicated by `CommandAPI.canRegister()` being false), this extra code is run to:
- Add commands to the server's `CommandMap`
- Add commands to the server's 'resources' `CommandDispatcher`
- 'Fix' permissions by adding them to the `VanillaCommandWrapper` version of the command
- Add the command to the help map
- Resend command packets to Players so they know about the new command

To help with this, two NMS methods were added:
```java
public interface NMS<CommandListenerWrapper> {
	/**
	 * Returns the Brigadier CommandDispatcher used when commands are sent to Players
	 *
	 * @return A Brigadier CommandDispatcher
	 */
	CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher();

	/**
	 * Wraps a Brigadier command node as Bukkit's VanillaCommandWrapper
	 *
	 * @param node The LiteralCommandNode to wrap
	 * @return A VanillaCommandWrapper representing the given node
	 */
	Command wrapToVanillaCommandWrapper(LiteralCommandNode<CommandListenerWrapper> node);
}
```

To test this feature, these commands were added.
```java
new CommandAPICommand("register")
	.withArguments(new StringArgument("command"))
	.withOptionalArguments(
		new GreedyStringArgument("aliases")
	)
	.executes(info -> {
		String name = info.args().getUnchecked("command");
		assert name != null;

		String aliasString = info.args().getUnchecked("aliases");
		String[] aliases;
		if(aliasString == null)
			aliases = new String[0];
		else
			aliases = aliasString.split(" ");

		new CommandAPICommand(name)
			.withAliases(aliases)
			.executes(i -> {
				i.sender().sendMessage("You ran the " + name + " command!");
			})
			.withPermission("dynamic." + name)
			.withShortDescription("New command!")
			.withFullDescription("This command was added while the server was running. Do you see it?")
			.register();
	})
	.register();

new CommandAPICommand("unregister")
	.withArguments(new StringArgument("command"))
	.executes(info -> {
		String name = info.args().getUnchecked("command");
		assert name != null;

		CommandAPI.unregister(name, true);
	})
	.register();

new CommandAPICommand("updateRequirements")
	.executesPlayer(info -> {
		CommandAPI.updateRequirements(info.sender());
	})
	.register();
```
 These test commands should be removed before merging

### TODO:
- [x] Merge update 1.20 and add support
- [x] Fix unregistering commands
- Test across all versions (registering and unregistering)
  - [x] 1.15, 1.15.1, 1.15.2
  - [x] 1.16.1
  - [x] 1.16.2, 1.16.3
  - [x] 1.16.4
  - [x] 1.16.5
  - [x] 1.17
  - [x] 1.17.1
  - [x] 1.18, 1.18.1
  - [x] 1.18.2
  - [x] 1.19
  - [x] 1.19.1, 1.19.2
  - [x] 1.19.3
  - [x] 1.19.4
  - [x] 1.20, 1.20.1
- [x] Remove message that things might not work (because they do now)
- Address code review
- [x] Fix tests
- [x] Add tests for unregistering commands
- [x] Update relevant documentation 
  - https://commandapi-live-docs.jorel.dev/commandregistration.html
- [x] ~~Check compatibility with https://github.com/PaperMC/Paper/pull/8235?~~ 9.0.3 is not currently compatible
- [x] Remove test commands