### PR TITLE
Add examples for Gradle projects and the CommandAPI Kotlin-DSL as a Gradle project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,6 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
+
+[docssrc/**]
+indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@ bin
 .project
 .settings
 target
+build
 **/logs/*.log
 **/logs/*.log.gz
 .vscode
 .DS_Store
 docssrc/src/.markdownlint-cli2.yaml
+.gradle

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandAPICommandDSL.kt
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandAPICommandDSL.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
 package dev.jorel.commandapi.kotlindsl
 
 import dev.jorel.commandapi.*
@@ -9,13 +11,13 @@ inline fun commandAPICommand(name: String, command: CommandAPICommand.() -> Unit
 inline fun commandAPICommand(name: String, predicate: Predicate<CommandSender>, command: CommandAPICommand.() -> Unit = {}) = CommandAPICommand(name).withRequirement(predicate).apply(command).register()
 
 inline fun CommandAPICommand.argument(base: Argument<*>, block: Argument<*>.() -> Unit = {}): CommandAPICommand = withArguments(base.apply(block))
-fun CommandAPICommand.arguments(vararg arguments: Argument<*>): CommandAPICommand = withArguments(*arguments)
+inline fun CommandAPICommand.arguments(vararg arguments: Argument<*>): CommandAPICommand = withArguments(*arguments)
 
 inline fun CommandAPICommand.optionalArgument(base: Argument<*>, block: Argument<*>.() -> Unit = {}): CommandAPICommand = withOptionalArguments(base.apply(block))
-fun CommandAPICommand.optionalArguments(vararg arguments: Argument<*>): CommandAPICommand = withOptionalArguments(*arguments)
+inline fun CommandAPICommand.optionalArguments(vararg arguments: Argument<*>): CommandAPICommand = withOptionalArguments(*arguments)
 
 inline fun subcommand(name: String, command: CommandAPICommand.() -> Unit = {}): CommandAPICommand = CommandAPICommand(name).apply(command)
-fun CommandAPICommand.subcommand(command: CommandAPICommand): CommandAPICommand = withSubcommand(command)
+inline fun CommandAPICommand.subcommand(command: CommandAPICommand): CommandAPICommand = withSubcommand(command)
 inline fun CommandAPICommand.subcommand(name: String, command: CommandAPICommand.() -> Unit = {}): CommandAPICommand = withSubcommand(CommandAPICommand(name).apply(command))
 
 // Integer arguments

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandAPICommandDSL.kt
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandAPICommandDSL.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
 package dev.jorel.commandapi.kotlindsl
 
 import com.velocitypowered.api.command.CommandSource
@@ -9,13 +11,13 @@ inline fun commandAPICommand(name: String, command: CommandAPICommand.() -> Unit
 inline fun commandAPICommand(name: String, predicate: Predicate<CommandSource>, command: CommandAPICommand.() -> Unit = {}) = CommandAPICommand(name).withRequirement(predicate).apply(command).register()
 
 inline fun CommandAPICommand.argument(base: Argument<*>, block: Argument<*>.() -> Unit = {}): CommandAPICommand = withArguments(base.apply(block))
-fun CommandAPICommand.arguments(vararg arguments: Argument<*>): CommandAPICommand = withArguments(*arguments)
+inline fun CommandAPICommand.arguments(vararg arguments: Argument<*>): CommandAPICommand = withArguments(*arguments)
 
 inline fun CommandAPICommand.optionalArgument(base: Argument<*>, block: Argument<*>.() -> Unit = {}): CommandAPICommand = withOptionalArguments(base.apply(block))
-fun CommandAPICommand.optionalArguments(vararg arguments: Argument<*>): CommandAPICommand = withOptionalArguments(*arguments)
+inline fun CommandAPICommand.optionalArguments(vararg arguments: Argument<*>): CommandAPICommand = withOptionalArguments(*arguments)
 
 inline fun subcommand(name: String, command: CommandAPICommand.() -> Unit = {}): CommandAPICommand = CommandAPICommand(name).apply(command)
-fun CommandAPICommand.subcommand(command: CommandAPICommand): CommandAPICommand = withSubcommand(command)
+inline fun CommandAPICommand.subcommand(command: CommandAPICommand): CommandAPICommand = withSubcommand(command)
 inline fun CommandAPICommand.subcommand(name: String, command: CommandAPICommand.() -> Unit = {}): CommandAPICommand = withSubcommand(CommandAPICommand(name).apply(command))
 
 // Integer arguments

--- a/docssrc/src/kotlinintro.md
+++ b/docssrc/src/kotlinintro.md
@@ -36,38 +36,6 @@ To install the DSL, you need to add the `commandapi-kotlin` dependency into your
 
 </div>
 
-Next, to shade it into your project easily, you need to add the `maven-shade-plugin`:
-
-```xml
-<build>
-    <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>3.3.0</version>
-            <executions>
-                <execution>
-                    <id>shade</id>
-                    <phase>package</phase>
-                    <goals>
-                        <goal>shade</goal>
-                    </goals>
-                </execution>
-            </executions>
-            <configuration>
-                <relocations>
-                    <relocation>
-                        <pattern>dev.jorel.commandapi.kotlindsl</pattern>
-                        <!-- TODO: Change this to my own package name -->
-                        <shadedPattern>my.custom.package.commandapi.kotlindsl</shadedPattern>
-                    </relocation>
-                </relocations>
-            </configuration>
-        </plugin>
-    </plugins>
-</build>
-```
-
 Next, you need to add Kotlin to your project. For this, you first need to add the dependency:
 
 ```xml
@@ -75,7 +43,7 @@ Next, you need to add Kotlin to your project. For this, you first need to add th
     <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.20</version>
     </dependency>
 </dependencies>
 ```
@@ -88,7 +56,7 @@ Finally, you need to add the `kotlin-maven-plugin`:
         <plugin>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-maven-plugin</artifactId>
-            <version>1.8.0</version>
+            <version>1.8.20</version>
             <executions>
                 <execution>
                     <id>compile</id>
@@ -163,69 +131,19 @@ dependencies {
 
 </div>
 
-Finally, you need to add it to the `shadowJar` configuration task and relocate it to your desired location:
-
-<div class="multi-pre">
-
-```groovy,Bukkit_build.gradle
-shadowJar {
-    dependencies {
-        include dependency("dev.jorel:commandapi-bukkit-kotlin:9.0.0")
-    }
-    
-    // TODO: Change this to my own package name
-    relocate("dev.jorel.commandapi", "my.custom.package.commandapi")
-}
-```
-
-```kotlin,Bukkit_build.gradle.kts
-shadowJar {
-    dependencies {
-        include dependency("dev.jorel:commandapi-bukkit-kotlin:9.0.0")
-    }
-    
-    // TODO: Change this to my own package name
-    relocate("dev.jorel.commandapi", "my.custom.package.commandapi")
-}
-```
-
-```groovy,Velocity_build.gradle
-shadowJar {
-    dependencies {
-        include dependency("dev.jorel:commandapi-velocity-kotlin:9.0.0")
-    }
-    
-    // TODO: Change this to my own package name
-    relocate("dev.jorel.commandapi", "my.custom.package.commandapi")
-}
-```
-
-```kotlin,Velocity_build.gradle.kts
-shadowJar {
-    dependencies {
-        include dependency("dev.jorel:commandapi-velocity-kotlin:9.0.0")
-    }
-    
-    // TODO: Change this to my own package name
-    relocate("dev.jorel.commandapi", "my.custom.package.commandapi")
-}
-```
-
-</div>
-
 You also need to add Kotlin to your project. For this, you first need to add the Kotlin plugin:
 
 <div class="multi-pre">
 
 ```groovy,build.gradle
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.8.0"
+    id "org.jetbrains.kotlin.jvm" version "1.8.20"
 }
 ```
 
 ```kotlin,build.gradle.kts
 plugins {
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "1.8.20"
 }
 ```
 
@@ -249,43 +167,19 @@ dependencies {
 
 </div>
 
-Then, you need to add the `compileKotlin` task:
+Then, you need to configure the Java version to build against:
 
 <div class="multi-pre">
 
 ```groovy,build.gradle
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "16"
-    }
+kotlin {
+	jvmToolchain(16)
 }
 ```
 
 ```kotlin,build.gradle.kts
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "16"
-}
-```
-
-</div>
-
-Finally, you need to add it to the `shadowJar` configuration task:
-
-<div class="multi-pre">
-
-```groovy,build.gradle
-shadowJar {
-    dependencies {
-        include dependency("org.jetbrains.kotlin:kotlin-stdlib")
-    }
-}
-```
-
-```kotlin,build.gradle.kts
-shadowJar {
-    dependencies {
-        include dependency("org.jetbrains.kotlin:kotlin-stdlib")
-    }
+kotlin {
+	jvmToolchain(16)
 }
 ```
 

--- a/docssrc/src/kotlinintro.md
+++ b/docssrc/src/kotlinintro.md
@@ -173,13 +173,13 @@ Then, you need to configure the Java version to build against:
 
 ```groovy,build.gradle
 kotlin {
-	jvmToolchain(16)
+    jvmToolchain(16)
 }
 ```
 
 ```kotlin,build.gradle.kts
 kotlin {
-	jvmToolchain(16)
+    jvmToolchain(16)
 }
 ```
 

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -3,9 +3,24 @@
 # Exit if any command fails
 set -e
 
+echo "Building Maven examples"
+
 # Find all pom.xml files
 for folder in $(find $PWD -name "pom.xml" | xargs dirname); do
 	if [[ ! $folder =~ "maven-shaded-tests" ]]; then
-		cd $folder && mvn clean package
+		# The parentheses are required to only change the directory for the command so the second find $PWD does not break
+		(cd "$folder" && mvn clean package)
 	fi
+done
+
+echo "Building Gradle examples"
+
+# Find all settings.gradle files
+for folder in $(find $PWD -name "build.gradle*" | xargs dirname); do
+	# Gradle does not output the name of the project that it is currently building
+	echo "$folder"
+	# Add "mavenLocal()" repository just for this step in ci.
+	# Generally in Gradle you should *never* use the mavenLocal() repository, but because we are doing this with
+	# versions of the plugin which are not published on Maven Central this hack is necessary.
+	(cd "$folder" && sed -i-backup -e "s/mavenCentral()/mavenCentral()\nmavenLocal()/g" build.gradle* && gradle clean jar)
 done

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -6,7 +6,7 @@ set -e
 echo "Building Maven examples"
 
 # Find all pom.xml files
-for folder in $(find $PWD -name "pom.xml" | xargs dirname); do
+for folder in $(find $PWD -name "pom.xml" -print0 | xargs -0 dirname); do
 	if [[ ! $folder =~ "maven-shaded-tests" ]]; then
 		# The parentheses are required to only change the directory for the command so the second find $PWD does not break
 		(cd "$folder" && mvn clean package)
@@ -16,7 +16,7 @@ done
 echo "Building Gradle examples"
 
 # Find all settings.gradle files
-for folder in $(find $PWD -name "build.gradle*" | xargs dirname); do
+for folder in $(find $PWD -name "build.gradle*" -print0 | xargs -0 dirname); do
 	# Gradle does not output the name of the project that it is currently building
 	echo "$folder"
 	# Add "mavenLocal()" repository just for this step in ci.

--- a/examples/bukkit/commandtrees/pom.xml
+++ b/examples/bukkit/commandtrees/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.19-R0.1-SNAPSHOT</version>
+			<version>1.19.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -37,9 +37,9 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.11.0</version>
 				<configuration>
-					<release>16</release>
+					<release>17</release>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/examples/bukkit/gradle-groovy/README.md
+++ b/examples/bukkit/gradle-groovy/README.md
@@ -1,0 +1,16 @@
+# Gradle Groovy
+
+A simple example of making a plugin that uses the CommandAPI with Maven.
+
+Key points:
+
+- The `commandapi-bukkit-plugin` dependency is used
+```groovy
+implementation 'dev.jorel:commandapi-bukkit-plugin:9.0.0-SNAPSHOT'
+```
+- In the plugin.yml, CommandAPI is listed as a depend:
+```yaml
+depend:
+    - CommandAPI
+```
+- Classes from the NBT API can be accessed in `dev.jorel.commandapi.nbtapi`

--- a/examples/bukkit/gradle-groovy/build.gradle
+++ b/examples/bukkit/gradle-groovy/build.gradle
@@ -4,8 +4,8 @@ plugins {
 
 java {
 	toolchain {
-		// Make the compiler against Java 16
-		languageVersion.set(JavaLanguageVersion.of(16))
+		// Make the compiler against Java 17
+		languageVersion.set(JavaLanguageVersion.of(17))
 	}
 }
 
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
 	// This adds the Spigot API artifact to the build
-	implementation 'org.spigotmc:spigot-api:1.18-R0.1-SNAPSHOT'
+	implementation 'org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT'
 
 	// The CommandAPI dependency used for Bukkit and it's forks
 	implementation 'dev.jorel:commandapi-bukkit-plugin:9.0.0-SNAPSHOT'

--- a/examples/bukkit/gradle-groovy/build.gradle
+++ b/examples/bukkit/gradle-groovy/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+	id 'java'
+}
+
+java {
+	toolchain {
+		// Make the compiler against Java 16
+		languageVersion.set(JavaLanguageVersion.of(16))
+	}
+}
+
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+	// Use Maven Central for resolving dependencies.
+	mavenCentral()
+	// This adds the Spigot Maven repository to the build
+	maven {
+		url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
+	}
+	// CodeMC repository for the NBT API
+	maven {
+		url 'https://repo.codemc.org/repository/maven-public/'
+	}
+}
+
+dependencies {
+	// This adds the Spigot API artifact to the build
+	implementation 'org.spigotmc:spigot-api:1.18-R0.1-SNAPSHOT'
+
+	// The CommandAPI dependency used for Bukkit and it's forks
+	implementation 'dev.jorel:commandapi-bukkit-plugin:9.0.0-SNAPSHOT'
+}

--- a/examples/bukkit/gradle-groovy/settings.gradle
+++ b/examples/bukkit/gradle-groovy/settings.gradle
@@ -1,0 +1,2 @@
+// This sets the name of the project. Most likely you want to change it to the name of the directory you are using
+rootProject.name = 'Example Plugin'

--- a/examples/bukkit/gradle-groovy/src/main/java/io/github/jorelali/Main.java
+++ b/examples/bukkit/gradle-groovy/src/main/java/io/github/jorelali/Main.java
@@ -1,0 +1,13 @@
+package io.github.jorelali;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class Main extends JavaPlugin {
+	@Override
+	public void onEnable() {
+		// Register commands using our MyCommands class
+		MyCommands myCommands = new MyCommands(this);
+		myCommands.registerAllCommands();
+		myCommands.registerAllCommandTrees();
+	}
+}

--- a/examples/bukkit/gradle-groovy/src/main/java/io/github/jorelali/MyCommands.java
+++ b/examples/bukkit/gradle-groovy/src/main/java/io/github/jorelali/MyCommands.java
@@ -1,0 +1,100 @@
+package io.github.jorelali;
+
+import dev.jorel.commandapi.nbtapi.NBTContainer;
+import dev.jorel.commandapi.CommandTree;
+import dev.jorel.commandapi.arguments.*;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import dev.jorel.commandapi.CommandAPICommand;
+
+public class MyCommands {
+
+	// Plugin reference in case we need to access anything about the plugin,
+	// such as its config.yml or something
+	private Plugin plugin;
+
+	public MyCommands(Plugin plugin) {
+		this.plugin = plugin;
+	}
+
+	public void registerAllCommands() {
+		// /break <location>
+		// Breaks a block at <location>. Can only be executed by a player
+		new CommandAPICommand("break")
+			// We want to target blocks in particular, so use BLOCK_POSITION
+			.withArguments(new LocationArgument("block", LocationType.BLOCK_POSITION))
+			.executesPlayer((player, args) -> {
+				((Location) args.get(0)).getBlock().breakNaturally();
+			})
+			.register();
+
+		// /myeffect <player> <potion effect>
+		// Applies a potion effect to a player. Basically a simple version of
+		// the /effect command. The potion effect with be a level 1 potion
+		// effect and the duration will be 5 minutes (300 seconds x 20 ticks)
+		new CommandAPICommand("myeffect")
+			.withArguments(new PlayerArgument("target"))
+			.withArguments(new PotionEffectArgument("potion"))
+			.executes((sender, args) -> {
+				Player target = (Player) args.get(0);
+				PotionEffectType potionEffectType = (PotionEffectType) args.get(1);
+				target.addPotionEffect(new PotionEffect(potionEffectType, 300 * 20, 1));
+			})
+			.register();
+
+		// An example of the NBTCompoundArgument
+		// The CommandAPI plugin includes tr7zw's NBT API for handling NBT data
+		// https://www.spigotmc.org/resources/nbt-api.7939/
+		new CommandAPICommand("nbt")
+			.withArguments(new NBTCompoundArgument<NBTContainer>("nbt"))
+			.executes(((sender, args) -> {
+				NBTContainer nbt = (NBTContainer) args.get(0);
+
+				sender.sendMessage(nbt.toString());
+			}))
+			.register();
+	}
+
+	public void registerAllCommandTrees() {
+		// This is a different method of registering commands
+		// Just for demonstration purposes I will use the same commands
+		// that have been registered in registerAllCommands()
+
+		// /break <location>
+		new CommandTree("break")
+			.then(new LocationArgument("block", LocationType.BLOCK_POSITION)
+				.executesPlayer((player, args) -> {
+					((Location) args.get(0)).getBlock().breakNaturally();
+				}))
+			.register();
+
+		// /myeffect
+		// This command will be changed a bit to demonstrate
+		// a way of optional arguments because it is not possible to
+		// add optional arguments using the CommandAPICommand method
+		new CommandTree("myeffect")
+			.then(new PotionEffectArgument("potion")
+				.executesPlayer((player, args) -> {
+					// Register /myeffect <potion effect>
+					// This command just adds the potion effect to the player that
+					// executes the command
+					PotionEffectType potionEffectType = (PotionEffectType) args.get(0);
+					player.addPotionEffect(new PotionEffect(potionEffectType, 300 * 20, 1));
+				})
+				.then(new PlayerArgument("target")
+					.executes((sender, args) -> {
+						// Register /myeffect <potion effect> <player>
+						// This command works exactly the same as the example
+						// shown in registerAllCommands()
+						PotionEffectType potionEffectType = (PotionEffectType) args.get(0);
+						Player target = (Player) args.get(1);
+						target.addPotionEffect(new PotionEffect(potionEffectType, 300 * 20, 1));
+					})))
+			.register();
+	}
+
+}

--- a/examples/bukkit/gradle-groovy/src/main/resources/plugin.yml
+++ b/examples/bukkit/gradle-groovy/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: ExamplePlugin
+main: io.github.jorelali.Main
+version: 0.0.1
+author: Skepter
+website: https://www.jorel.dev/CommandAPI/
+api-version: 1.13
+depend:
+    - CommandAPI

--- a/examples/bukkit/gradle-kotlin/README.md
+++ b/examples/bukkit/gradle-kotlin/README.md
@@ -1,0 +1,16 @@
+# Gradle Kotlin
+
+A simple example of making a plugin that uses the CommandAPI with Maven.
+
+Key points:
+
+- The `commandapi-bukkit-plugin` dependency is used
+```kotlin
+implementation("dev.jorel:commandapi-bukkit-plugin:9.0.0-SNAPSHOT")
+```
+- In the plugin.yml, CommandAPI is listed as a depend:
+```yaml
+depend:
+    - CommandAPI
+```
+- Classes from the NBT API can be accessed in `dev.jorel.commandapi.nbtapi`

--- a/examples/bukkit/gradle-kotlin/build.gradle.kts
+++ b/examples/bukkit/gradle-kotlin/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+	java
+}
+
+java {
+	toolchain {
+		// Make the compiler against Java 16
+		languageVersion.set(JavaLanguageVersion.of(16))
+	}
+}
+
+version = "0.0.1-SNAPSHOT"
+
+repositories {
+	// Use Maven Central for resolving dependencies.
+	mavenCentral()
+	// This adds the Spigot Maven repository to the build
+	maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
+	// CodeMC repository for the NBT API
+	maven("https://repo.codemc.org/repository/maven-public/")
+}
+
+dependencies {
+	// This adds the Spigot API artifact to the build
+	implementation("org.spigotmc:spigot-api:1.18-R0.1-SNAPSHOT")
+
+	// The CommandAPI dependency used for Bukkit and it's forks
+	implementation("dev.jorel:commandapi-bukkit-plugin:9.0.0-SNAPSHOT")
+}

--- a/examples/bukkit/gradle-kotlin/build.gradle.kts
+++ b/examples/bukkit/gradle-kotlin/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 
 java {
 	toolchain {
-		// Make the compiler against Java 16
-		languageVersion.set(JavaLanguageVersion.of(16))
+		// Make the compiler against Java 17
+		languageVersion.set(JavaLanguageVersion.of(17))
 	}
 }
 
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
 	// This adds the Spigot API artifact to the build
-	implementation("org.spigotmc:spigot-api:1.18-R0.1-SNAPSHOT")
+	implementation("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
 
 	// The CommandAPI dependency used for Bukkit and it's forks
 	implementation("dev.jorel:commandapi-bukkit-plugin:9.0.0-SNAPSHOT")

--- a/examples/bukkit/gradle-kotlin/settings.gradle.kts
+++ b/examples/bukkit/gradle-kotlin/settings.gradle.kts
@@ -1,0 +1,2 @@
+// This sets the name of the project. Most likely you want to change it to the name of the directory you are using
+rootProject.name = "Example Plugin"

--- a/examples/bukkit/gradle-kotlin/settings.gradle.kts
+++ b/examples/bukkit/gradle-kotlin/settings.gradle.kts
@@ -1,2 +1,2 @@
 // This sets the name of the project. Most likely you want to change it to the name of the directory you are using
-rootProject.name = "Example Plugin"
+rootProject.name = "gradle-kotlin"

--- a/examples/bukkit/gradle-kotlin/src/main/java/io/github/jorelali/Main.java
+++ b/examples/bukkit/gradle-kotlin/src/main/java/io/github/jorelali/Main.java
@@ -1,0 +1,13 @@
+package io.github.jorelali;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class Main extends JavaPlugin {
+	@Override
+	public void onEnable() {
+		// Register commands using our MyCommands class
+		MyCommands myCommands = new MyCommands(this);
+		myCommands.registerAllCommands();
+		myCommands.registerAllCommandTrees();
+	}
+}

--- a/examples/bukkit/gradle-kotlin/src/main/java/io/github/jorelali/MyCommands.java
+++ b/examples/bukkit/gradle-kotlin/src/main/java/io/github/jorelali/MyCommands.java
@@ -1,0 +1,100 @@
+package io.github.jorelali;
+
+import dev.jorel.commandapi.nbtapi.NBTContainer;
+import dev.jorel.commandapi.CommandTree;
+import dev.jorel.commandapi.arguments.*;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import dev.jorel.commandapi.CommandAPICommand;
+
+public class MyCommands {
+
+	// Plugin reference in case we need to access anything about the plugin,
+	// such as its config.yml or something
+	private Plugin plugin;
+
+	public MyCommands(Plugin plugin) {
+		this.plugin = plugin;
+	}
+
+	public void registerAllCommands() {
+		// /break <location>
+		// Breaks a block at <location>. Can only be executed by a player
+		new CommandAPICommand("break")
+			// We want to target blocks in particular, so use BLOCK_POSITION
+			.withArguments(new LocationArgument("block", LocationType.BLOCK_POSITION))
+			.executesPlayer((player, args) -> {
+				((Location) args.get(0)).getBlock().breakNaturally();
+			})
+			.register();
+
+		// /myeffect <player> <potion effect>
+		// Applies a potion effect to a player. Basically a simple version of
+		// the /effect command. The potion effect with be a level 1 potion
+		// effect and the duration will be 5 minutes (300 seconds x 20 ticks)
+		new CommandAPICommand("myeffect")
+			.withArguments(new PlayerArgument("target"))
+			.withArguments(new PotionEffectArgument("potion"))
+			.executes((sender, args) -> {
+				Player target = (Player) args.get(0);
+				PotionEffectType potionEffectType = (PotionEffectType) args.get(1);
+				target.addPotionEffect(new PotionEffect(potionEffectType, 300 * 20, 1));
+			})
+			.register();
+
+		// An example of the NBTCompoundArgument
+		// The CommandAPI plugin includes tr7zw's NBT API for handling NBT data
+		// https://www.spigotmc.org/resources/nbt-api.7939/
+		new CommandAPICommand("nbt")
+			.withArguments(new NBTCompoundArgument<NBTContainer>("nbt"))
+			.executes(((sender, args) -> {
+				NBTContainer nbt = (NBTContainer) args.get(0);
+
+				sender.sendMessage(nbt.toString());
+			}))
+			.register();
+	}
+
+	public void registerAllCommandTrees() {
+		// This is a different method of registering commands
+		// Just for demonstration purposes I will use the same commands
+		// that have been registered in registerAllCommands()
+
+		// /break <location>
+		new CommandTree("break")
+			.then(new LocationArgument("block", LocationType.BLOCK_POSITION)
+				.executesPlayer((player, args) -> {
+					((Location) args.get(0)).getBlock().breakNaturally();
+				}))
+			.register();
+
+		// /myeffect
+		// This command will be changed a bit to demonstrate
+		// a way of optional arguments because it is not possible to
+		// add optional arguments using the CommandAPICommand method
+		new CommandTree("myeffect")
+			.then(new PotionEffectArgument("potion")
+				.executesPlayer((player, args) -> {
+					// Register /myeffect <potion effect>
+					// This command just adds the potion effect to the player that
+					// executes the command
+					PotionEffectType potionEffectType = (PotionEffectType) args.get(0);
+					player.addPotionEffect(new PotionEffect(potionEffectType, 300 * 20, 1));
+				})
+				.then(new PlayerArgument("target")
+					.executes((sender, args) -> {
+						// Register /myeffect <potion effect> <player>
+						// This command works exactly the same as the example
+						// shown in registerAllCommands()
+						PotionEffectType potionEffectType = (PotionEffectType) args.get(0);
+						Player target = (Player) args.get(1);
+						target.addPotionEffect(new PotionEffect(potionEffectType, 300 * 20, 1));
+					})))
+			.register();
+	}
+
+}

--- a/examples/bukkit/gradle-kotlin/src/main/resources/plugin.yml
+++ b/examples/bukkit/gradle-kotlin/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: ExamplePlugin
+main: io.github.jorelali.Main
+version: 0.0.1
+author: Skepter
+website: https://www.jorel.dev/CommandAPI/
+api-version: 1.13
+depend:
+    - CommandAPI

--- a/examples/bukkit/kotlindsl-gradle/README.md
+++ b/examples/bukkit/kotlindsl-gradle/README.md
@@ -1,4 +1,4 @@
-# kotlin-dsl
+# kotlin-dsl Gradle
 
 A simple example showcasing creating a command using the Kotlin DSL for the CommandAPI!
 
@@ -7,11 +7,7 @@ Key points:
 - You do not need to use the `.register()` method
 - You do not need to initialise any arguments.
 - Add the `commandapi-kotlin-bukkit` dependency to your project
-```xml
-<dependency>
-	<groupId>dev.jorel</groupId>
-	<artifactId>commandapi-kotlin-bukkit</artifactId>
-	<version>9.0.0-SNAPSHOT</version>
-</dependency>
+```kotlin
+compileOnly("dev.jorel:commandapi-bukkit-kotlin:9.0.0-SNAPSHOT")
 ```
 - The Kotlin DSL must not be shaded into your plugin

--- a/examples/bukkit/kotlindsl-gradle/build.gradle.kts
+++ b/examples/bukkit/kotlindsl-gradle/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 	implementation("org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT")
 
 	// The CommandAPI dependency used for Bukkit and it's forks
-	implementation("dev.jorel:commandapi-bukkit-plugin:9.0.0-SNAPSHOT")
+	implementation("dev.jorel:commandapi-bukkit-core:9.0.0-SNAPSHOT")
 	// Due to all functions available in the kotlindsl being inlined, we only need this dependency at compile-time
 	compileOnly("dev.jorel:commandapi-bukkit-kotlin:9.0.0-SNAPSHOT")
 }

--- a/examples/bukkit/kotlindsl-gradle/build.gradle.kts
+++ b/examples/bukkit/kotlindsl-gradle/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-	jvmToolchain(16)
+	jvmToolchain(17)
 }
 
 version = "0.0.1-SNAPSHOT"
@@ -13,15 +13,13 @@ repositories {
 	mavenCentral()
 	// This adds the Spigot Maven repository to the build
 	maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
-	// CodeMC repository for the NBT API
-	maven("https://repo.codemc.org/repository/maven-public/")
 }
 
 dependencies {
 	implementation(kotlin("stdlib-jdk8"))
 
 	// This adds the Spigot API artifact to the build
-	implementation("org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT")
+	implementation("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
 
 	// The CommandAPI dependency used for Bukkit and it's forks
 	implementation("dev.jorel:commandapi-bukkit-core:9.0.0-SNAPSHOT")

--- a/examples/bukkit/kotlindsl-gradle/build.gradle.kts
+++ b/examples/bukkit/kotlindsl-gradle/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+	kotlin("jvm") version "1.8.20"
+}
+
+kotlin {
+	jvmToolchain(16)
+}
+
+version = "0.0.1-SNAPSHOT"
+
+repositories {
+	// Use Maven Central for resolving dependencies.
+	mavenCentral()
+	// This adds the Spigot Maven repository to the build
+	maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
+	// CodeMC repository for the NBT API
+	maven("https://repo.codemc.org/repository/maven-public/")
+}
+
+dependencies {
+	implementation(kotlin("stdlib-jdk8"))
+
+	// This adds the Spigot API artifact to the build
+	implementation("org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT")
+
+	// The CommandAPI dependency used for Bukkit and it's forks
+	implementation("dev.jorel:commandapi-bukkit-plugin:9.0.0-SNAPSHOT")
+	// Due to all functions available in the kotlindsl being inlined, we only need this dependency at compile-time
+	compileOnly("dev.jorel:commandapi-bukkit-kotlin:9.0.0-SNAPSHOT")
+}

--- a/examples/bukkit/kotlindsl-gradle/settings.gradle.kts
+++ b/examples/bukkit/kotlindsl-gradle/settings.gradle.kts
@@ -1,2 +1,2 @@
 // This sets the name of the project. Most likely you want to change it to the name of the directory you are using
-rootProject.name = 'gradle-groovy'
+rootProject.name = "kotlindsl-gradle"

--- a/examples/bukkit/kotlindsl-gradle/src/main/kotlin/io/github/jorelali/Main.kt
+++ b/examples/bukkit/kotlindsl-gradle/src/main/kotlin/io/github/jorelali/Main.kt
@@ -1,0 +1,10 @@
+package io.github.jorelali
+
+import org.bukkit.plugin.java.JavaPlugin
+
+class Main : JavaPlugin() {
+
+	override fun onEnable() {
+		SayHelloCommand().register()
+	}
+}

--- a/examples/bukkit/kotlindsl-gradle/src/main/kotlin/io/github/jorelali/SayHelloCommand.kt
+++ b/examples/bukkit/kotlindsl-gradle/src/main/kotlin/io/github/jorelali/SayHelloCommand.kt
@@ -1,0 +1,25 @@
+package io.github.jorelali
+
+import dev.jorel.commandapi.kotlindsl.*
+import org.bukkit.entity.Player
+
+class SayHelloCommand {
+
+	fun register() {
+		commandTree("sayhello") {
+			playerArgument("target") {
+				playerExecutor { player, args ->
+					val target: Player = args[0] as Player
+					target.sendMessage("§6${player.name} says hello to you!")
+				}
+			}
+		}
+
+		commandAPICommand("suicide") {
+			literalArgument("confirm")
+			playerExecutor { player, _ ->
+				player.health = 0.0
+			}
+		}
+	}
+}

--- a/examples/bukkit/kotlindsl-gradle/src/main/resources/plugin.yml
+++ b/examples/bukkit/kotlindsl-gradle/src/main/resources/plugin.yml
@@ -1,0 +1,7 @@
+name: KotlinDSL
+main: io.github.jorelali.Main
+version: 0.0.1
+author: DerEchtePilz
+website: https://www.jorel.dev/CommandAPI/
+api-version: 1.13
+depend: [CommandAPI]

--- a/examples/bukkit/kotlindsl/pom.xml
+++ b/examples/bukkit/kotlindsl/pom.xml
@@ -20,7 +20,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>dev.jorel</groupId>
-			<artifactId>commandapi-bukkit-plugin</artifactId>
+			<artifactId>commandapi-bukkit-core</artifactId>
 			<version>9.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>

--- a/examples/bukkit/kotlindsl/pom.xml
+++ b/examples/bukkit/kotlindsl/pom.xml
@@ -10,7 +10,7 @@
 	</properties>
 
 	<repositories>
-		<!-- This adds the Paper Maven repository to the build -->
+		<!-- This adds the Spigot Maven repository to the build -->
 		<repository>
 			<id>spigot-repo</id>
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
@@ -30,11 +30,11 @@
 			<version>9.0.0-SNAPSHOT</version>
 		</dependency>
 
-		<!--This adds the Paper API artifact to the build -->
+		<!--This adds the Spigot API artifact to the build -->
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.19.2-R0.1-SNAPSHOT</version>
+			<version>1.19.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -75,7 +75,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.11.0</version>
 				<executions>
 					<!-- Replacing default-compile as it is treated specially by maven -->
 					<execution>

--- a/examples/bukkit/kotlindsl/pom.xml
+++ b/examples/bukkit/kotlindsl/pom.xml
@@ -6,35 +6,34 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<kotlin.version>1.7.20</kotlin.version>
+		<kotlin.version>1.8.20</kotlin.version>
 	</properties>
 
 	<repositories>
 		<!-- This adds the Paper Maven repository to the build -->
 		<repository>
-			<id>papermc</id>
-			<url>https://papermc.io/repo/repository/maven-public/</url>
+			<id>spigot-repo</id>
+			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 		</repository>
 	</repositories>
 
 	<dependencies>
 		<dependency>
 			<groupId>dev.jorel</groupId>
+			<artifactId>commandapi-bukkit-plugin</artifactId>
+			<version>9.0.0-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-kotlin</artifactId>
 			<version>9.0.0-SNAPSHOT</version>
 		</dependency>
 
-		<dependency>
-			<groupId>dev.jorel</groupId>
-			<artifactId>commandapi-bukkit-core</artifactId>
-			<version>9.0.0-SNAPSHOT</version>
-			<scope>provided</scope>
-		</dependency>
-
 		<!--This adds the Paper API artifact to the build -->
 		<dependency>
-			<groupId>io.papermc.paper</groupId>
-			<artifactId>paper-api</artifactId>
+			<groupId>org.spigotmc</groupId>
+			<artifactId>spigot-api</artifactId>
 			<version>1.19.2-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
@@ -43,41 +42,11 @@
 			<artifactId>kotlin-stdlib</artifactId>
 			<version>${kotlin.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-test</artifactId>
-			<version>${kotlin.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>
 		<sourceDirectory>src/main/kotlin</sourceDirectory>
 		<plugins>
-			<!-- Shade the CommandAPI Kotlin DSL into the jar -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.3.1-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<createDependencyReducedPom>false</createDependencyReducedPom>
-							<relocations>
-								<relocation>
-									<pattern>dev.jorel.commandapi.kotlindsl</pattern>
-									<shadedPattern>io.github.jorelali.commandapi.kotlindsl</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
 			<!-- Usual Kotlin configuration -->
 			<plugin>
 				<groupId>org.jetbrains.kotlin</groupId>
@@ -142,11 +111,4 @@
 			</resource>
 		</resources>
 	</build>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>maven-snapshots</id>
-			<url>https://repository.apache.org/content/repositories/snapshots/</url>
-		</pluginRepository>
-	</pluginRepositories>
 </project>

--- a/examples/bukkit/kotlindsl/src/main/kotlin/io/github/jorelali/Main.kt
+++ b/examples/bukkit/kotlindsl/src/main/kotlin/io/github/jorelali/Main.kt
@@ -1,15 +1,10 @@
 package io.github.jorelali
 
-import dev.jorel.commandapi.CommandAPI
-import dev.jorel.commandapi.CommandAPIBukkitConfig
 import org.bukkit.plugin.java.JavaPlugin
 
 class Main : JavaPlugin() {
 
 	override fun onEnable() {
-		CommandAPI.onLoad(CommandAPIBukkitConfig(this))
-		CommandAPI.onEnable()
 		SayHelloCommand().register()
 	}
-
 }

--- a/examples/bukkit/maven-annotations/pom.xml
+++ b/examples/bukkit/maven-annotations/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18-R0.1-SNAPSHOT</version>
+			<version>1.19.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -57,7 +57,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.11.0</version>
 				<configuration>
 					<annotationProcessorPaths>
 						<path>

--- a/examples/bukkit/maven-shaded-annotations/pom.xml
+++ b/examples/bukkit/maven-shaded-annotations/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18-R0.1-SNAPSHOT</version>
+			<version>1.19.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -56,7 +56,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.11.0</version>
 				<configuration>
 					<annotationProcessorPaths>
 						<path>
@@ -65,14 +65,14 @@
 							<version>9.0.0-SNAPSHOT</version>
 						</path>
 					</annotationProcessorPaths>
-					<release>16</release>
+					<release>17</release>
 				</configuration>
 			</plugin>
 			<!-- Add necessary classes into our plugin jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.4.1</version>
 				<executions>
 					<execution>
 						<id>shade</id>

--- a/examples/bukkit/maven-shaded-tests/pom.xml
+++ b/examples/bukkit/maven-shaded-tests/pom.xml
@@ -106,16 +106,16 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.11.0</version>
 				<configuration>
-					<release>16</release>
+					<release>17</release>
 				</configuration>
 			</plugin>
 			<!-- Add necessary classes into our plugin jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.4.1</version>
 				<executions>
 					<execution>
 						<id>shade</id>

--- a/examples/bukkit/maven-shaded/pom.xml
+++ b/examples/bukkit/maven-shaded/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18-R0.1-SNAPSHOT</version>
+			<version>1.19.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -52,16 +52,16 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.11.0</version>
 				<configuration>
-					<release>16</release>
+					<release>17</release>
 				</configuration>
 			</plugin>
 			<!-- Add necessary classes into our plugin jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.4.1</version>
 				<executions>
 					<execution>
 						<id>shade</id>

--- a/examples/bukkit/maven/pom.xml
+++ b/examples/bukkit/maven/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18-R0.1-SNAPSHOT</version>
+			<version>1.19.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -47,9 +47,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.11.0</version>
 				<configuration>
-					<release>16</release>
+					<release>17</release>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/examples/velocity/gradle-groovy/README.md
+++ b/examples/velocity/gradle-groovy/README.md
@@ -1,0 +1,17 @@
+# Gradle Groovy
+
+A simple example of making a plugin that uses the CommandAPI with Maven.
+
+Key points:
+
+- The `commandapi-velocity-core` dependency is used
+```groovy
+implementation 'dev.jorel:commandapi-velocity-core:9.0.0-SNAPSHOT'
+```
+- In the `@Plugin` annotation, `commandapi` is listed as a dependency:
+```java
+@Plugin(id = "maven-example", description = "An example for using the CommandAPI with maven",
+// Add a dependency on the CommandAPI
+dependencies = {@Dependency(id = "commandapi")})
+```
+

--- a/examples/velocity/gradle-groovy/build.gradle
+++ b/examples/velocity/gradle-groovy/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+	id 'java'
+}
+
+java {
+	toolchain {
+		// Make the compiler against Java 16
+		languageVersion.set(JavaLanguageVersion.of(16))
+	}
+}
+
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+	// Use Maven Central for resolving dependencies.
+	mavenCentral()
+	// This adds the Velocity Maven repository to the build
+	maven {
+		url 'https://repo.papermc.io/repository/maven-public/'
+	}
+}
+
+dependencies {
+	// This adds the Velocity API artifact to the build
+	implementation 'com.velocitypowered:velocity-api:3.1.1'
+
+	// The CommandAPI dependency used for Velocity
+	implementation 'dev.jorel:commandapi-velocity-core:9.0.0-SNAPSHOT'
+}

--- a/examples/velocity/gradle-groovy/build.gradle
+++ b/examples/velocity/gradle-groovy/build.gradle
@@ -4,8 +4,8 @@ plugins {
 
 java {
 	toolchain {
-		// Make the compiler against Java 16
-		languageVersion.set(JavaLanguageVersion.of(16))
+		// Make the compiler against Java 17
+		languageVersion.set(JavaLanguageVersion.of(17))
 	}
 }
 

--- a/examples/velocity/gradle-groovy/settings.gradle
+++ b/examples/velocity/gradle-groovy/settings.gradle
@@ -1,2 +1,2 @@
 // This sets the name of the project. Most likely you want to change it to the name of the directory you are using
-rootProject.name = 'Example Plugin'
+rootProject.name = 'gradle-groovy'

--- a/examples/velocity/gradle-groovy/settings.gradle
+++ b/examples/velocity/gradle-groovy/settings.gradle
@@ -1,0 +1,2 @@
+// This sets the name of the project. Most likely you want to change it to the name of the directory you are using
+rootProject.name = 'Example Plugin'

--- a/examples/velocity/gradle-groovy/src/main/java/io/github/jorelali/Main.java
+++ b/examples/velocity/gradle-groovy/src/main/java/io/github/jorelali/Main.java
@@ -1,0 +1,27 @@
+package io.github.jorelali;
+
+import com.velocitypowered.api.plugin.Dependency;
+import com.velocitypowered.api.plugin.Plugin;
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.GreedyStringArgument;
+import net.kyori.adventure.text.Component;
+
+import javax.inject.Inject;
+import java.util.logging.Logger;
+
+@Plugin(id = "maven-example", description = "An example for using the CommandAPI with maven",
+// Add a dependency on the CommandAPI
+dependencies = {@Dependency(id = "commandapi")})
+public class Main {
+	@Inject
+	public Main(Logger logger) {
+		logger.info("Creating commands");
+		// Create commands
+		new CommandAPICommand("echo")
+			.withArguments(new GreedyStringArgument("message"))
+			.executes(((sender, args) -> {
+				sender.sendMessage(Component.text((String) args.get(0)));
+			}))
+			.register();
+	}
+}

--- a/examples/velocity/gradle-kotlin/README.md
+++ b/examples/velocity/gradle-kotlin/README.md
@@ -1,0 +1,17 @@
+# Gradle Kotlin
+
+A simple example of making a plugin that uses the CommandAPI with Maven.
+
+Key points:
+
+- The `commandapi-velocity-core` dependency is used
+```kotlin
+implementation("dev.jorel:commandapi-velocity-core:9.0.0-SNAPSHOT")
+```
+- In the `@Plugin` annotation, `commandapi` is listed as a dependency:
+```java
+@Plugin(id = "maven-example", description = "An example for using the CommandAPI with maven",
+// Add a dependency on the CommandAPI
+dependencies = {@Dependency(id = "commandapi")})
+```
+

--- a/examples/velocity/gradle-kotlin/build.gradle.kts
+++ b/examples/velocity/gradle-kotlin/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+	java
+}
+
+java {
+	toolchain {
+		// Make the compiler against Java 16
+		languageVersion.set(JavaLanguageVersion.of(16))
+	}
+}
+
+version = "0.0.1-SNAPSHOT"
+
+repositories {
+	// Use Maven Central for resolving dependencies.
+	mavenCentral()
+	// This adds the Velocity Maven repository to the build
+	maven("https://repo.papermc.io/repository/maven-public/")
+}
+
+dependencies {
+	// This adds the Velocity API artifact to the build
+	implementation("com.velocitypowered:velocity-api:3.1.1")
+
+	// The CommandAPI dependency used for Velocity
+	implementation("dev.jorel:commandapi-velocity-core:9.0.0-SNAPSHOT")
+}

--- a/examples/velocity/gradle-kotlin/build.gradle.kts
+++ b/examples/velocity/gradle-kotlin/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 
 java {
 	toolchain {
-		// Make the compiler against Java 16
-		languageVersion.set(JavaLanguageVersion.of(16))
+		// Make the compiler against Java 17
+		languageVersion.set(JavaLanguageVersion.of(17))
 	}
 }
 

--- a/examples/velocity/gradle-kotlin/settings.gradle.kts
+++ b/examples/velocity/gradle-kotlin/settings.gradle.kts
@@ -1,0 +1,2 @@
+// This sets the name of the project. Most likely you want to change it to the name of the directory you are using
+rootProject.name = "Example Plugin"

--- a/examples/velocity/gradle-kotlin/settings.gradle.kts
+++ b/examples/velocity/gradle-kotlin/settings.gradle.kts
@@ -1,2 +1,2 @@
 // This sets the name of the project. Most likely you want to change it to the name of the directory you are using
-rootProject.name = "Example Plugin"
+rootProject.name = "gradle-kotlin"

--- a/examples/velocity/gradle-kotlin/src/main/java/io/github/jorelali/Main.java
+++ b/examples/velocity/gradle-kotlin/src/main/java/io/github/jorelali/Main.java
@@ -1,0 +1,27 @@
+package io.github.jorelali;
+
+import com.velocitypowered.api.plugin.Dependency;
+import com.velocitypowered.api.plugin.Plugin;
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.GreedyStringArgument;
+import net.kyori.adventure.text.Component;
+
+import javax.inject.Inject;
+import java.util.logging.Logger;
+
+@Plugin(id = "maven-example", description = "An example for using the CommandAPI with maven",
+// Add a dependency on the CommandAPI
+dependencies = {@Dependency(id = "commandapi")})
+public class Main {
+	@Inject
+	public Main(Logger logger) {
+		logger.info("Creating commands");
+		// Create commands
+		new CommandAPICommand("echo")
+			.withArguments(new GreedyStringArgument("message"))
+			.executes(((sender, args) -> {
+				sender.sendMessage(Component.text((String) args.get(0)));
+			}))
+			.register();
+	}
+}

--- a/examples/velocity/maven-shaded/pom.xml
+++ b/examples/velocity/maven-shaded/pom.xml
@@ -38,7 +38,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.11.0</version>
 				<configuration>
 					<release>16</release>
 				</configuration>
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.4.1</version>
 				<executions>
 					<execution>
 						<id>shade</id>

--- a/examples/velocity/maven/pom.xml
+++ b/examples/velocity/maven/pom.xml
@@ -40,9 +40,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.11.0</version>
 				<configuration>
-					<release>16</release>
+					<release>17</release>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 		<maven.compiler.source>16</maven.compiler.source>
 		<maven.compiler.target>16</maven.compiler.target>
 		<java.version>16</java.version>
-		<kotlin.version>1.8.0</kotlin.version>
+		<kotlin.version>1.8.20</kotlin.version>
 
 		<!-- Shared libraries. These are declared here so they can be updated easily. 
 			These are present in each module to prevent accidentally "leaking" these 


### PR DESCRIPTION
Noteworthy is that I changed some functions in the KotlinDSL to inline even though they do not benefit from that because that way, the Kotlin DSL does not need to be shaded into the final plugin because everything is inlined.