### PR TITLE
Folia Support

### DIFF
--- a/commandapi-core/pom.xml
+++ b/commandapi-core/pom.xml
@@ -49,11 +49,18 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>dev.folia</groupId>
+			<artifactId>folia-api</artifactId>
+			<version>1.19.4-R0.1-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.papermc.paper</groupId>
 			<artifactId>paper-api</artifactId>
 			<version>${paper.version}</version>
 			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>com.mojang</groupId>
 			<artifactId>brigadier</artifactId>

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/SchedulerUtils.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/SchedulerUtils.java
@@ -1,0 +1,35 @@
+package dev.jorel.commandapi;
+
+import dev.jorel.commandapi.CommandAPI;
+import org.bukkit.plugin.Plugin;
+
+public class SchedulerUtils {
+
+	public static int scheduleSyncRepeatingTask(Plugin plugin, long delay, long period, Runnable runnable) {
+		if (CommandAPI.isFoliaServer()) {
+			plugin.getServer().getGlobalRegionScheduler().runAtFixedRate(plugin, task -> runnable.run(), delay, period);
+			return 1;
+		} else return plugin.getServer().getScheduler().scheduleSyncRepeatingTask(plugin, runnable, delay, period);
+	}
+
+	public static void cancelTask(Plugin plugin, int id) {
+		if (CommandAPI.isFoliaServer()) plugin.getServer().getGlobalRegionScheduler().cancelTasks(plugin);
+		else plugin.getServer().getScheduler().cancelTask(id);
+	}
+
+	public static void execute(Runnable runnable, Plugin plugin) {
+		if (CommandAPI.isFoliaServer()) plugin.getServer().getGlobalRegionScheduler().execute(plugin, runnable);
+		else plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, runnable);
+	}
+
+	public static void executeDelayed(Runnable runnable, Plugin plugin, long delay) {
+		if (CommandAPI.isFoliaServer()) plugin.getServer().getGlobalRegionScheduler().execute(plugin, runnable);
+		else plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, runnable, delay);
+	}
+
+	public static void executeAsync(Runnable runnable, Plugin plugin) {
+		if (CommandAPI.isFoliaServer()) plugin.getServer().getGlobalRegionScheduler().execute(plugin, runnable);
+		else plugin.getServer().getScheduler().runTaskAsynchronously(plugin, runnable);
+	}
+
+}


### PR DESCRIPTION
This primarily fixes the base issue of CommandAPI not loading on Folia.
Not meant to be merged. As noted in #432 , Datapacks dont work and currently cause spits out a warning.
Just for showing the stuff mentioned in the original issue
The basic logic for commands etc seems to function with this relatively small change

Tested with oraxen/oraxen/#799