### PR TITLE
Add utility getter for argument count on CommandArguments object

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/executors/CommandArguments.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/executors/CommandArguments.java
@@ -32,6 +32,13 @@ public class CommandArguments {
 	// Access the inner structure directly
 
 	/**
+	 * @return The number of arguments in this object
+	 */
+	public int count() {
+		return args.length;
+	}
+
+	/**
 	 * @return The complete argument array of this command
 	 */
 	public Object[] args() {


### PR DESCRIPTION
Adds CommandArguments#count() utility method to get the number of arguments. 