### PR TITLE
Implementing methods which return Optionals in CommandArguments.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,9 +372,10 @@ This is the current roadmap for the CommandAPI (as of 2nd November 2022):
             <td valign="top">May 2023</td>
             <td valign="top">
                 <ul>
-                    <li>Fixed <code>MapArgument</code> not allowing player names as keys</li>
+                    <li>Fixed <code>MapArgument</code> not always allowing player names as keys</li>
                     <li>Fixed <code>/execute as ...</code> not working due to casting to a player instead of a proxied sender</li>
                     <li>https://github.com/JorelAli/CommandAPI/pull/441 Adds <code>CommandArguments#count()</code> utility method</li>
+                    <li>https://github.com/JorelAli/CommandAPI/issues/440 Adds several <code>CommandArguments#getOptional()</code> methods</li>
                 </ul>
             </td>
         </tr>

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/executors/CommandArguments.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/executors/CommandArguments.java
@@ -4,6 +4,7 @@ import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -32,13 +33,6 @@ public class CommandArguments {
 	// Access the inner structure directly
 
 	/**
-	 * @return The number of arguments in this object
-	 */
-	public int count() {
-		return args.length;
-	}
-
-	/**
 	 * @return The complete argument array of this command
 	 */
 	public Object[] args() {
@@ -50,6 +44,13 @@ public class CommandArguments {
 	 */
 	public Map<String, Object> argsMap() {
 		return Collections.unmodifiableMap(argsMap);
+	}
+
+	/**
+	 * @return The number of arguments in this object
+	 */
+	public int count() {
+		return args.length;
 	}
 	
 	// Main accessing methods. In Kotlin, methods named get() allows it to
@@ -98,14 +99,13 @@ public class CommandArguments {
 	 * Returns an argument by its index
 	 *
 	 * @param index The position of this argument
-	 * @param defaultValue The Object returned if the argument is not existent
 	 * @return An argument which is placed at the given index, or the provided default value
 	 */
-	public Object getOrDefault(int index, Object defaultValue) {
+	public Optional<Object> getOptional(int index) {
 		if (args.length <= index) {
-			return defaultValue;
+			return Optional.empty();
 		} else {
-			return args[index];
+			return Optional.of(args[index]);
 		}
 	}
 
@@ -113,37 +113,13 @@ public class CommandArguments {
 	 * Returns an argument by its node name
 	 *
 	 * @param nodeName     The node name of this argument. This was set when initializing an argument
-	 * @param defaultValue The Object returned if the argument was not found.
 	 * @return The argument with the specified node name or the provided default value
 	 */
-	public Object getOrDefault(String nodeName, Object defaultValue) {
-		return argsMap.getOrDefault(nodeName, defaultValue);
-	}
-
-	/**
-	 * Returns an argument by its index
-	 *
-	 * @param index The position of this argument
-	 * @param defaultValue The Object returned if the argument is not existent
-	 * @return An argument which is placed at the given index, or the provided default value
-	 */
-	public Object getOrDefault(int index, Supplier<?> defaultValue) {
-		if (args.length <= index) {
-			return defaultValue.get();
-		} else {
-			return args[index];
+	public Optional<Object> getOptional(String nodeName) {
+		if (!argsMap.containsKey(nodeName)) {
+			return Optional.empty();
 		}
-	}
-
-	/**
-	 * Returns an argument by its node name
-	 *
-	 * @param nodeName     The node name of this argument. This was set when initializing an argument
-	 * @param defaultValue The Object returned if the argument was not found.
-	 * @return The argument with the specified node name or the provided default value
-	 */
-	public Object getOrDefault(String nodeName, Supplier<?> defaultValue) {
-		return argsMap.getOrDefault(nodeName, defaultValue.get());
+		return Optional.of(argsMap.get(nodeName));
 	}
 	
 	/** Unchecked methods. These are the same as the methods above, but use
@@ -191,46 +167,22 @@ public class CommandArguments {
 	}
 
 	/**
-	 * Returns an argument by its index
+	 * Returns an <code>Optional</code> holding the argument at its index
 	 *
 	 * @param index The position of this argument
-	 * @param defaultValue The Object returned if the argument is not existent
-	 * @return An argument which is placed at the given index, or the provided default value
+	 * @return An optional which holds the argument at its index
 	 */
-	public <T> T getOrDefaultUnchecked(int index, T defaultValue) {
-		return (T) getOrDefault(index, defaultValue);
+	public <T> Optional<T> getOptionalUnchecked(int index) {
+		return (Optional<T>) getOptional(index);
 	}
 
 	/**
-	 * Returns an argument by its node name
+	 * Returns an <code>Optional</code> holding the argument by its node name
 	 *
 	 * @param nodeName     The node name of this argument. This was set when initializing an argument
-	 * @param defaultValue The Object returned if the argument was not found.
-	 * @return The argument with the specified node name or the provided default value
+	 * @return The argument with the specified node name
 	 */
-	public <T> T getOrDefaultUnchecked(String nodeName, T defaultValue) {
-		return (T) getOrDefault(nodeName, defaultValue);
-	}
-
-	/**
-	 * Returns an argument by its index
-	 *
-	 * @param index The position of this argument
-	 * @param defaultValue The Object returned if the argument is not existent
-	 * @return An argument which is placed at the given index, or the provided default value
-	 */
-	public <T> T getOrDefaultUnchecked(int index, Supplier<T> defaultValue) {
-		return (T) getOrDefault(index, defaultValue);
-	}
-
-	/**
-	 * Returns an argument by its node name
-	 *
-	 * @param nodeName     The node name of this argument. This was set when initializing an argument
-	 * @param defaultValue The Object returned if the argument was not found.
-	 * @return The argument with the specified node name or the provided default value
-	 */
-	public <T> T getOrDefaultUnchecked(String nodeName, Supplier<T> defaultValue) {
-		return (T) getOrDefault(nodeName, defaultValue);
+	public <T> Optional<T> getOptionalUnchecked(String nodeName) {
+		return (Optional<T>) getOptional(nodeName);
 	}
 }

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/executors/CommandArguments.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/executors/CommandArguments.java
@@ -92,14 +92,72 @@ public class CommandArguments {
 	public String getFullInput() {
 		return fullInput;
 	}
-	
-	// Optional accessing methods
 
 	/**
 	 * Returns an argument by its index
 	 *
 	 * @param index The position of this argument
+	 * @param defaultValue The Object returned if the argument is not existent
+	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptional(int)
 	 * @return An argument which is placed at the given index, or the provided default value
+	 */
+	@Deprecated(since = "9.0.1", forRemoval = true)
+	public Object getOrDefault(int index, Object defaultValue) {
+		if (args.length <= index) {
+			return defaultValue;
+		} else {
+			return args[index];
+		}
+	}
+
+	/**
+	 * Returns an argument by its node name
+	 *
+	 * @param nodeName     The node name of this argument. This was set when initializing an argument
+	 * @param defaultValue The Object returned if the argument was not found.
+	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptional(String)
+	 * @return The argument with the specified node name or the provided default value
+	 */
+	@Deprecated(since = "9.0.1", forRemoval = true)
+	public Object getOrDefault(String nodeName, Object defaultValue) {
+		return argsMap.getOrDefault(nodeName, defaultValue);
+	}
+
+	/**
+	 * Returns an argument by its index
+	 *
+	 * @param index The position of this argument
+	 * @param defaultValue The Object returned if the argument is not existent
+	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptional(int)
+	 * @return An argument which is placed at the given index, or the provided default value
+	 */
+	@Deprecated(since = "9.0.1", forRemoval = true)
+	public Object getOrDefault(int index, Supplier<?> defaultValue) {
+		if (args.length <= index) {
+			return defaultValue.get();
+		} else {
+			return args[index];
+		}
+	}
+
+	/**
+	 * Returns an argument by its node name
+	 *
+	 * @param nodeName     The node name of this argument. This was set when initializing an argument
+	 * @param defaultValue The Object returned if the argument was not found.
+	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptional(String)
+	 * @return The argument with the specified node name or the provided default value
+	 */
+	@Deprecated(since = "9.0.1", forRemoval = true)
+	public Object getOrDefault(String nodeName, Supplier<?> defaultValue) {
+		return argsMap.getOrDefault(nodeName, defaultValue.get());
+	}
+
+	/**
+	 * Returns an <code>Optional</code> holding the argument by its index
+	 *
+	 * @param index The position of this argument
+	 * @return An optional holding the argument which is placed at the given index, or an empty optional if index is invalid
 	 */
 	public Optional<Object> getOptional(int index) {
 		if (args.length <= index) {
@@ -113,7 +171,7 @@ public class CommandArguments {
 	 * Returns an argument by its node name
 	 *
 	 * @param nodeName     The node name of this argument. This was set when initializing an argument
-	 * @return The argument with the specified node name or the provided default value
+	 * @return An optional holding the argument with the specified node name or an empty optional if the node name was not found
 	 */
 	public Optional<Object> getOptional(String nodeName) {
 		if (!argsMap.containsKey(nodeName)) {
@@ -167,10 +225,62 @@ public class CommandArguments {
 	}
 
 	/**
+	 * Returns an argument by its index
+	 *
+	 * @param index The position of this argument
+	 * @param defaultValue The Object returned if the argument is not existent
+	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptionalUnchecked(int)
+	 * @return An argument which is placed at the given index, or the provided default value
+	 */
+	@Deprecated(since = "9.0.1", forRemoval = true)
+	public <T> T getOrDefaultUnchecked(int index, T defaultValue) {
+		return (T) getOrDefault(index, defaultValue);
+	}
+
+	/**
+	 * Returns an argument by its node name
+	 *
+	 * @param nodeName     The node name of this argument. This was set when initializing an argument
+	 * @param defaultValue The Object returned if the argument was not found.
+	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptionalUnchecked(String)
+	 * @return The argument with the specified node name or the provided default value
+	 */
+	@Deprecated(since = "9.0.1", forRemoval = true)
+	public <T> T getOrDefaultUnchecked(String nodeName, T defaultValue) {
+		return (T) getOrDefault(nodeName, defaultValue);
+	}
+
+	/**
+	 * Returns an argument by its index
+	 *
+	 * @param index The position of this argument
+	 * @param defaultValue The Object returned if the argument is not existent
+	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptionalUnchecked(int)
+	 * @return An argument which is placed at the given index, or the provided default value
+	 */
+	@Deprecated(since = "9.0.1", forRemoval = true)
+	public <T> T getOrDefaultUnchecked(int index, Supplier<T> defaultValue) {
+		return (T) getOrDefault(index, defaultValue);
+	}
+
+	/**
+	 * Returns an argument by its node name
+	 *
+	 * @param nodeName     The node name of this argument. This was set when initializing an argument
+	 * @param defaultValue The Object returned if the argument was not found.
+	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptionalUnchecked(String)
+	 * @return The argument with the specified node name or the provided default value
+	 */
+	@Deprecated(since = "9.0.1", forRemoval = true)
+	public <T> T getOrDefaultUnchecked(String nodeName, Supplier<T> defaultValue) {
+		return (T) getOrDefault(nodeName, defaultValue);
+	}
+
+	/**
 	 * Returns an <code>Optional</code> holding the argument at its index
 	 *
 	 * @param index The position of this argument
-	 * @return An optional which holds the argument at its index
+	 * @return An optional holding the argument at its index, or an empty optional if the index was invalid
 	 */
 	public <T> Optional<T> getOptionalUnchecked(int index) {
 		return (Optional<T>) getOptional(index);
@@ -180,9 +290,10 @@ public class CommandArguments {
 	 * Returns an <code>Optional</code> holding the argument by its node name
 	 *
 	 * @param nodeName     The node name of this argument. This was set when initializing an argument
-	 * @return The argument with the specified node name
+	 * @return An optional holding the argument with the specified node name, or an empty optional if the index was invalid
 	 */
 	public <T> Optional<T> getOptionalUnchecked(String nodeName) {
 		return (Optional<T>) getOptional(nodeName);
 	}
+
 }

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/executors/CommandArguments.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/executors/CommandArguments.java
@@ -98,7 +98,7 @@ public class CommandArguments {
 	 *
 	 * @param index The position of this argument
 	 * @param defaultValue The Object returned if the argument is not existent
-	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptional(int)
+	 * @deprecated This method has been deprecated! Please use {@link CommandArguments#getOptional(int)}
 	 * @return An argument which is placed at the given index, or the provided default value
 	 */
 	@Deprecated(since = "9.0.1", forRemoval = true)
@@ -115,7 +115,7 @@ public class CommandArguments {
 	 *
 	 * @param nodeName     The node name of this argument. This was set when initializing an argument
 	 * @param defaultValue The Object returned if the argument was not found.
-	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptional(String)
+	 * @deprecated This method has been deprecated! Please use {@link CommandArguments#getOptional(String)}
 	 * @return The argument with the specified node name or the provided default value
 	 */
 	@Deprecated(since = "9.0.1", forRemoval = true)
@@ -128,7 +128,7 @@ public class CommandArguments {
 	 *
 	 * @param index The position of this argument
 	 * @param defaultValue The Object returned if the argument is not existent
-	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptional(int)
+	 * @deprecated This method has been deprecated! Please use {@link CommandArguments#getOptional(int)}
 	 * @return An argument which is placed at the given index, or the provided default value
 	 */
 	@Deprecated(since = "9.0.1", forRemoval = true)
@@ -145,7 +145,7 @@ public class CommandArguments {
 	 *
 	 * @param nodeName     The node name of this argument. This was set when initializing an argument
 	 * @param defaultValue The Object returned if the argument was not found.
-	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptional(String)
+	 * @deprecated This method has been deprecated! Please use {@link CommandArguments#getOptional(String)}
 	 * @return The argument with the specified node name or the provided default value
 	 */
 	@Deprecated(since = "9.0.1", forRemoval = true)
@@ -229,7 +229,7 @@ public class CommandArguments {
 	 *
 	 * @param index The position of this argument
 	 * @param defaultValue The Object returned if the argument is not existent
-	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptionalUnchecked(int)
+	 * @deprecated This method has been deprecated! Please use {@link CommandArguments#getOptionalUnchecked(int)}
 	 * @return An argument which is placed at the given index, or the provided default value
 	 */
 	@Deprecated(since = "9.0.1", forRemoval = true)
@@ -242,7 +242,7 @@ public class CommandArguments {
 	 *
 	 * @param nodeName     The node name of this argument. This was set when initializing an argument
 	 * @param defaultValue The Object returned if the argument was not found.
-	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptionalUnchecked(String)
+	 * @deprecated This method has been deprecated! Please use {@link CommandArguments#getOptionalUnchecked(String)}
 	 * @return The argument with the specified node name or the provided default value
 	 */
 	@Deprecated(since = "9.0.1", forRemoval = true)
@@ -255,7 +255,7 @@ public class CommandArguments {
 	 *
 	 * @param index The position of this argument
 	 * @param defaultValue The Object returned if the argument is not existent
-	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptionalUnchecked(int)
+	 * @deprecated This method has been deprecated! Please use {@link CommandArguments#getOptionalUnchecked(int)}
 	 * @return An argument which is placed at the given index, or the provided default value
 	 */
 	@Deprecated(since = "9.0.1", forRemoval = true)
@@ -268,7 +268,7 @@ public class CommandArguments {
 	 *
 	 * @param nodeName     The node name of this argument. This was set when initializing an argument
 	 * @param defaultValue The Object returned if the argument was not found.
-	 * @deprecated This method has been deprecated! Please use CommandArguments#getOptionalUnchecked(String)
+	 * @deprecated This method has been deprecated! Please use {@link CommandArguments#getOptionalUnchecked(String)}
 	 * @return The argument with the specified node name or the provided default value
 	 */
 	@Deprecated(since = "9.0.1", forRemoval = true)

--- a/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
+++ b/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
@@ -1637,7 +1637,7 @@ new CommandAPICommand("rate")
         int rating = (int) args.get("rating");
 
         // The target player is optional, so give it a default here
-        CommandSender target = (CommandSender) args.getOrDefault("target", sender);
+        CommandSender target = (CommandSender) args.getOptional("target").orElse(sender);
 
         target.sendMessage("Your " + topic + " was rated: " + rating + "/10");
     })

--- a/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
+++ b/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
@@ -1637,7 +1637,7 @@ new CommandAPICommand("rate")
         int rating = (int) args.get("rating");
 
         // The target player is optional, so give it a default here
-        CommandSender target = (CommandSender) args.getOptional("target").orElse(sender);
+        CommandSender target = (CommandSender) args.getOrDefault("target", sender);
 
         target.sendMessage("Your " + topic + " was rated: " + rating + "/10");
     })

--- a/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
+++ b/commandapi-documentation-code/src/main/java/dev/jorel/commandapi/examples/java/Examples.java
@@ -1612,7 +1612,7 @@ new CommandAPICommand("sayhi")
 new CommandAPICommand("sayhi")
     .withOptionalArguments(new PlayerArgument("target"))
     .executesPlayer((player, args) -> {
-        Player target = (Player) args.getOrDefault("target", player);
+        Player target = (Player) args.getOptional("target").orElse(player);
         target.sendMessage("Hi!");
     })
     .register();

--- a/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
+++ b/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
@@ -1524,7 +1524,7 @@ CommandAPICommand("sayhi")
 CommandAPICommand("sayhi")
     .withOptionalArguments(PlayerArgument("target"))
     .executesPlayer(PlayerCommandExecutor { player, args ->
-        val target: Player = args.getOrDefault("target", player) as Player
+        val target: Player = args.getOptional("target").orElse(player) as Player
         target.sendMessage("Hi!")
     })
     .register()

--- a/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
+++ b/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
@@ -1549,7 +1549,7 @@ CommandAPICommand("rate")
         val rating = args["rating"] as Int
 
         // The target player is optional, so give it a default here
-        val target: CommandSender = args.getOptional("target").orElse(sender) as CommandSender
+        val target: CommandSender = args.getOrDefault("target", sender) as CommandSender
 
         target.sendMessage("Your $topic was rated: $rating/10")
     })

--- a/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
+++ b/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/Examples.kt
@@ -1549,7 +1549,7 @@ CommandAPICommand("rate")
         val rating = args["rating"] as Int
 
         // The target player is optional, so give it a default here
-        val target: CommandSender = args.getOrDefault("target", sender) as CommandSender
+        val target: CommandSender = args.getOptional("target").orElse(sender) as CommandSender
 
         target.sendMessage("Your $topic was rated: $rating/10")
     })

--- a/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/ExamplesKotlinDSL.kt
+++ b/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/ExamplesKotlinDSL.kt
@@ -1081,7 +1081,7 @@ commandAPICommand("sayhi") {
 commandAPICommand("sayhi") {
     playerArgument("target", optional = true)
     playerExecutor { player, args ->
-        val target: Player = args.getOrDefault("target", player) as Player
+        val target: Player = args.getOptional("target").orElse(player) as Player
         target.sendMessage("Hi!")
     }
 }

--- a/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/ExamplesKotlinDSL.kt
+++ b/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/ExamplesKotlinDSL.kt
@@ -1106,7 +1106,7 @@ commandAPICommand("rate") {
         val rating = args["rating"] as Int
 
         // The target player is optional, so give it a default here
-        val target: CommandSender = args.getOptional("target").orElse(sender) as CommandSender
+        val target: CommandSender = args.getOrDefault("target", sender) as CommandSender
 
         target.sendMessage("Your $topic was rated: $rating/10")
     }

--- a/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/ExamplesKotlinDSL.kt
+++ b/commandapi-documentation-code/src/main/kotlin/dev/jorel/commandapi/examples/kotlin/ExamplesKotlinDSL.kt
@@ -1106,7 +1106,7 @@ commandAPICommand("rate") {
         val rating = args["rating"] as Int
 
         // The target player is optional, so give it a default here
-        val target: CommandSender = args.getOrDefault("target", sender) as CommandSender
+        val target: CommandSender = args.getOptional("target").orElse(sender) as CommandSender
 
         target.sendMessage("Your $topic was rated: $rating/10")
     }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/arguments/OptionalArgumentTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/arguments/OptionalArgumentTests.java
@@ -144,27 +144,7 @@ class OptionalArgumentTests extends TestBase {
 		new CommandAPICommand("test")
 			.withOptionalArguments(new StringArgument("string"))
 			.executesPlayer((player, args) -> {
-				type.set((String) args.getOrDefault("string", "hello"));
-			})
-			.register();
-
-		PlayerMock player = server.addPlayer();
-
-		server.dispatchCommand(player, "test");
-		server.dispatchCommand(player, "test world");
-
-		assertEquals("hello", type.get());
-		assertEquals("world", type.get());
-	}
-
-	@Test
-	void testOptionalArgumentDefaultWithSupplier() {
-		Mut<String> type = Mut.of();
-
-		new CommandAPICommand("test")
-			.withOptionalArguments(new StringArgument("string"))
-			.executesPlayer((player, args) -> {
-				type.set((String) args.getOrDefault("string", () -> "hello"));
+				type.set((String) args.getOptional("string").orElse("hello"));
 			})
 			.register();
 
@@ -203,7 +183,7 @@ class OptionalArgumentTests extends TestBase {
 		new CommandAPICommand("test")
 			.withOptionalArguments(new StringArgument("string"))
 			.executesPlayer((player, args) -> {
-				type.set((String) args.getOrDefault(0, "hello"));
+				type.set((String) args.getOptional(0).orElse("hello"));
 			})
 			.register();
 
@@ -222,7 +202,7 @@ class OptionalArgumentTests extends TestBase {
 		new CommandAPICommand("test")
 			.withOptionalArguments(new StringArgument("string"))
 			.executesPlayer((player, args) -> {
-				type.set((String) args.getOrDefault(0, () -> "hello"));
+				type.set((String) args.getOptional(0).orElse("hello"));
 			})
 			.register();
 

--- a/docssrc/src/intro.md
+++ b/docssrc/src/intro.md
@@ -37,6 +37,10 @@ Using the search icon <i class="fas fa-search"></i> in the top left corner, you 
 
 Here's the list of changes to the documentation between each update. You can view the current documentation version at the top of this page.
 
+### Documentation changes 9.0.0 \\(\rightarrow\\) 9.0.1
+
+- Updates [Optional arguments](./optional_arguments.md) page to update the method list for avoiding `null` values
+
 ### Documentation changes 8.8.0 \\(\rightarrow\\) 9.0.0
 
 > **Developer's Note:**

--- a/docssrc/src/optional_arguments.md
+++ b/docssrc/src/optional_arguments.md
@@ -98,16 +98,16 @@ Optional<Object> getOptional(String nodeName)
 
 <div class="example">
 
-### Example - /sayhi command while using the getOptional method
+### Example - /sayhi command while using the getOrDefault method
 
-Let's register the `/sayhi` command from above a second time - this time using a `getOptional` method. We are using the exact same command syntax:
+Let's register the `/sayhi` command from above a second time - this time using a `getOrDefault` method. We are using the exact same command syntax:
 
 ```mccmd
 /sayhi          - Says "Hi!" to yourself
 /sayhi <target> - Says "Hi!" to a target player
 ```
 
-This is how the `getOptional` method is being implemented:
+This is how the `getOrDefault` method is being implemented:
 
 <div class="multi-pre">
 

--- a/docssrc/src/optional_arguments.md
+++ b/docssrc/src/optional_arguments.md
@@ -98,16 +98,16 @@ Optional<Object> getOptional(String nodeName)
 
 <div class="example">
 
-### Example - /sayhi command while using the getOrDefault method
+### Example - /sayhi command while using the getOptional method
 
-Let's register the `/sayhi` command from above a second time - this time using a `getOrDefault` method. We are using the exact same command syntax:
+Let's register the `/sayhi` command from above a second time - this time using a `getOptional` method. We are using the exact same command syntax:
 
 ```mccmd
 /sayhi          - Says "Hi!" to yourself
 /sayhi <target> - Says "Hi!" to a target player
 ```
 
-This is how the `getOrDefault` method is being implemented:
+This is how the `getOptional` method is being implemented:
 
 <div class="multi-pre">
 

--- a/docssrc/src/optional_arguments.md
+++ b/docssrc/src/optional_arguments.md
@@ -78,13 +78,22 @@ However, calling `withOptionalArguments` is safer because it makes sure that the
 
 ## Avoiding null values
 
-Previously, we've looked at how to handle null values. To make all of this easier, the CommandAPI implements multiple `getOrDefault()` methods for `CommandArguments`:
+Previously, we've looked at how to handle null values. To make all of this easier, the CommandAPI implements multiple `getOptional()` methods for `CommandArguments`:
+
+<div class="warning">
+
+> **Developer's Note:**
+> 
+> For 9.0.1, all `CommandArguments#getOrDefault()` methods have been deprecated and new methods have been added!
+> The existing methods will be removed in an upcoming version!
+>
+> View them below:
+
+</div>
 
 ```java
-Object getOrDefault(int index, Object defaultValue)
-Object getOrDefault(String nodeName, Object defaultValue)
-Object getOrDefault(int index, Supplier<?> defaultValue)
-Object getOrDefault(String nodeName, Supplier<?> defaultValue)
+Optional<Object> getOptional(int index)
+Optional<Object> getOptional(String nodeName)
 ```
 
 <div class="example">

--- a/docssrc/src/upgrading.md
+++ b/docssrc/src/upgrading.md
@@ -1,5 +1,59 @@
 # Upgrading guide
 
+## From 9.0.0 to 9.0.1
+
+### CommandArguments changes
+
+For 9.0.1 the various `CommandArguments#getOrDefault()` and `CommandArguments#getOrDefaultUnchecked()` have been deprecated and should no longer be used. Instead, use the `CommandArguments#getOptional()` and `CommandArguments#getOptionalUnchecked()` methods:
+
+<div class="multi-pre">
+
+```java,9.0.0_(Not using unchecked)
+new CommandAPICommand("mycommand")
+    .withOptionalArguments(new StringArgument("string"))
+    .executes((sender, args) -> {
+        String string = (String) args.getOrDefault("string", "Default Value");
+    })
+    .register();
+```
+
+```java,9.0.0_(Using unchecked)
+new CommandAPICommand("mycommand")
+    .withOptionalArguments(new StringArgument("string"))
+    .executes((sender, args) -> {
+        String string = args.getOrDefaultUnchecked("string", "Default Value);
+    })
+    .register();
+```
+
+</div>
+
+$$\downarrow$$
+
+<div class="multi-pre">
+
+```java,9.0.1_(Not using unchecked)
+new CommandAPICommand("mycommand")
+    .withOptionalArguments(new StringArgument("string"))
+    .executes((sender, args) -> {
+        String string = (String) args.getOptional("string").orElse("Default Value");
+    })
+    .register();
+```
+
+```java,9.0.1_(Using unchecked)
+new CommandAPICommand("mycommand")
+    .withOptionalArguments(new StringArgument("string"))
+    .executes((sender, args) -> {
+        String string = args.getOptionalUnchecked("string").orElse("Default Value);
+    })
+    .register();
+```
+
+</div>
+
+----
+
 ## From 8.8.x to 9.0.0
 
 CommandAPI 9.0.0 is arguably the biggest change in the CommandAPI's project structure and usage. This update was designed to allow the CommandAPI to be generalized for other platforms (e.g. Velocity, Fabric, Sponge), and as a result **this update is incompatible with previous versions of the CommandAPI**.


### PR DESCRIPTION
Key changes:
- `CommandArguments#getOrDefault()` has been replaced with `CommandArguments#getOptional()`
- `CommandArguments#getOrDefaultUnchecked()` has been replaced with `CommandArguments#getOptionalUnchecked()`

The old methods still exist but have been deprecated and will be removed in the future!

This implements #440 