### PR TITLE
Set SonarCloud variables to target correct branch

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -53,6 +53,19 @@ jobs:
                   git clean -ffdx && git reset --hard HEAD
 
             # Set up
+              # Credit to https://www.ackama.com/what-we-think/values-github-actions/ for helping me figure these two steps out :P
+            - name: Set SonarCloud branch
+              run: |
+                  branchName = ${{ github.event.workflow_run.head_branch }}
+                  echo "Branch is named $branchName"
+                  echo "sonar.branch.name=$branchName" >> $GITHUB_ENV
+            - name: Set SonarCloud target
+              if: github.event.workflow_run.event == 'pull_request'
+              run: |
+                  branchTarget = ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+                  echo "PR targets $branchTarget"
+                  echo "sonar.branch.target=$branchTarget" >> $GITHUB_ENV
+
             - name: Setup JDK 17
               uses: actions/setup-java@v3
               with:


### PR DESCRIPTION
Fixes something weird where all SonarCloud analyses would show up under `dev/dev` instead of their actual branch (hopefully, if not, expect another PR!).