### PR TITLE
Add Kotlin DSL example code for shading

### DIFF
--- a/docssrc/src/setup_shading.md
+++ b/docssrc/src/setup_shading.md
@@ -238,11 +238,11 @@ shadowJar {
 ```
 
 ```kotlin,build.gradle.kts
-shadowJar {
+tasks.withType<ShadowJar> {
     dependencies {
-        include dependency("dev.jorel:commandapi-bukkit-shade:9.0.4")
+        include(dependency("dev.jorel:commandapi-bukkit-shade:9.0.4"))
     }
-
+    
     // TODO: Change this to my own package name
     relocate("dev.jorel.commandapi", "my.custom.package.commandapi")
 }

--- a/docssrc/src/setup_shading.md
+++ b/docssrc/src/setup_shading.md
@@ -238,7 +238,7 @@ shadowJar {
 ```
 
 ```kotlin,build.gradle.kts
-tasks.withType<ShadowJar> {
+shadowJar {
     dependencies {
         include(dependency("dev.jorel:commandapi-bukkit-shade:9.0.4"))
     }


### PR DESCRIPTION
Added a missing Kotlin DSL example in the [Shading the CommandAPI in your plugins](https://commandapi.jorel.dev/9.0.3/setup_shading.html#shading-the-commandapi-in-your-plugins) portion of the documentation.