### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/arguments/AdventureChatComponentArgument.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/arguments/AdventureChatComponentArgument.java
@@ -37,7 +37,7 @@ public class AdventureChatComponentArgument extends Argument<Component> {
 
 	/**
 	 * Constructs a ChatComponent argument with a given node name. Represents raw JSON text, used in Book MetaData, Chat and other various areas of Minecraft
-	 * @see <a href="https://minecraft.gamepedia.com/Commands#Raw_JSON_text">Raw JSON text</a> 
+	 * @see <a href="https://minecraft.wiki/w/Commands#Raw_JSON_text">Raw JSON text</a> 
 	 * @param nodeName the name of the node for argument
 	 */
 	public AdventureChatComponentArgument(String nodeName) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/arguments/ChatComponentArgument.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/arguments/ChatComponentArgument.java
@@ -40,7 +40,7 @@ public class ChatComponentArgument extends Argument<BaseComponent[]> {
 	 * Constructs a ChatComponent argument with a given node name. Represents raw
 	 * JSON text, used in Book MetaData, Chat and other various areas of Minecraft
 	 * 
-	 * @see <a href="https://minecraft.gamepedia.com/Commands#Raw_JSON_text">Raw
+	 * @see <a href="https://minecraft.wiki/w/Commands#Raw_JSON_text">Raw
 	 *      JSON text</a>
 	 * @param nodeName the name of the node for argument
 	 */

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/arguments/ArgumentBlockStateTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/arguments/ArgumentBlockStateTests.java
@@ -41,7 +41,7 @@ class ArgumentBlockStateTests extends TestBase {
 	 * Tests *
 	 *********/
 	
-	// Block states can be looked up here: https://minecraft.fandom.com/wiki/Block_states
+	// Block states can be looked up here: https://minecraft.wiki/w/Block_states
 
 	@Test
 	void executionTestWithBlockStateArgument() {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/arguments/ArgumentItemStackTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/arguments/ArgumentItemStackTests.java
@@ -74,7 +74,7 @@ class ArgumentItemStackTests extends TestBase {
 		// Dev note: To make these tests work, we have to overwrite MockBukkit's
 		// ItemFactory with our own, see CommandAPIServerMock#getItemFactory()
 		
-		// NBT examples from https://minecraft.fandom.com/wiki/Tutorials/Command_NBT_tags#Items
+		// NBT examples from https://minecraft.wiki/w/Tutorials/Command_NBT_tags#Items
 		
 		// /test minecraft:stone{Count:3b}
 		{

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/arguments/ArgumentLocationTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/arguments/ArgumentLocationTests.java
@@ -96,7 +96,7 @@ class ArgumentLocationTests extends TestBase {
 			server.dispatchCommand(player, "test ^ ^ ^5");
 			assertLocationEquals(new Location(null, 2.0, 2.0, 7.0), results.get());
 			
-			// As defined in https://minecraft.fandom.com/wiki/Coordinates#Local_coordinates:
+			// As defined in https://minecraft.wiki/w/Coordinates#Local_coordinates:
 			// For example, /tp ^ ^ ^5 teleports the player 5 blocks forward. If they turn
 			// around and repeat the command, they are teleported back to where they
 			// started.
@@ -170,7 +170,7 @@ class ArgumentLocationTests extends TestBase {
 			server.dispatchCommand(player, "test ^ ^ ^5");
 			assertLocationEquals(new Location(null, 2, 2, 7), results.get());
 			
-			// As defined in https://minecraft.fandom.com/wiki/Coordinates#Local_coordinates:
+			// As defined in https://minecraft.wiki/w/Coordinates#Local_coordinates:
 			// For example, /tp ^ ^ ^5 teleports the player 5 blocks forward. If they turn
 			// around and repeat the command, they are teleported back to where they
 			// started.

--- a/docssrc/src/argument_blockpredicate.md
+++ b/docssrc/src/argument_blockpredicate.md
@@ -1,6 +1,6 @@
 # Block predicate arguments
 
-The `BlockPredicateArgument` is used to represent a "test" for Minecraft blocks. This can consist of tags, such as the ones listed [here on the MinecraftWiki](https://minecraft.gamepedia.com/Tag#Blocks), or individual blocks. If a block matches the tag or block, then the predicate is satisfied.
+The `BlockPredicateArgument` is used to represent a "test" for Minecraft blocks. This can consist of tags, such as the ones listed [here on the MinecraftWiki](https://minecraft.wiki/w/Tag#Blocks), or individual blocks. If a block matches the tag or block, then the predicate is satisfied.
 
 For example, if we were to use the predicate `#leaves`, then the following blocks will be satisfied by that predicate: `jungle_leaves`, `oak_leaves`, `spruce_leaves`, `dark_oak_leaves`, `acacia_leaves`, `birch_leaves`.
 

--- a/docssrc/src/argument_chat_adventure.md
+++ b/docssrc/src/argument_chat_adventure.md
@@ -50,7 +50,7 @@ We then use the `ChatColorArgument` to change the player's name color:
 
 ## Adventure chat component argument
 
-The `AdventureChatComponentArgument` class accepts raw chat-based JSON as valid input, as declared [here](https://minecraft.gamepedia.com/Raw_JSON_text_format). This is converted into Adventure's `Component` class.
+The `AdventureChatComponentArgument` class accepts raw chat-based JSON as valid input, as declared [here](https://minecraft.wiki/w/Raw_JSON_text_format). This is converted into Adventure's `Component` class.
 
 <div class="example">
 

--- a/docssrc/src/argument_chat_spigot.md
+++ b/docssrc/src/argument_chat_spigot.md
@@ -45,7 +45,7 @@ We then use the `ChatColorArgument` to change the player's name color:
 
 ## Chat component argument
 
-The `ChatComponentArgument` class accepts raw chat-based JSON as valid input. Despite being regular JSON, it _must_ conform to the standard declared [here](https://minecraft.gamepedia.com/Raw_JSON_text_format), which consists of JSON that has a limited subset of specific keys (In other words, you can have a JSON object that has the key `text`, but not one that has the key `blah`).
+The `ChatComponentArgument` class accepts raw chat-based JSON as valid input. Despite being regular JSON, it _must_ conform to the standard declared [here](https://minecraft.wiki/w/Raw_JSON_text_format), which consists of JSON that has a limited subset of specific keys (In other words, you can have a JSON object that has the key `text`, but not one that has the key `blah`).
 
 This is converted into Spigot's `BaseComponent[]`, which can be used for the following:
 

--- a/docssrc/src/argument_chats.md
+++ b/docssrc/src/argument_chats.md
@@ -4,7 +4,7 @@ The CommandAPI provides a number of ways to interact with chat formatting in Min
 
 - **ChatColor**: The color of text rendered in Minecraft
 - **Chat**: Text which is said in chat. This also includes entity selectors such as `@a` and `@r`
-- **ChatComponent**: Minecraft's [Raw JSON text format](https://minecraft.gamepedia.com/Raw_JSON_text_format)
+- **ChatComponent**: Minecraft's [Raw JSON text format](https://minecraft.wiki/w/Raw_JSON_text_format)
 
 The CommandAPI implements **ChatColor**, **Chat** and **ChatComponent** in two separate ways: [Spigot-compatible](./argument_chat_spigot.md) and [Adventure-compatible](./argument_chat_adventure.md). The differences between these and how to use them are described in their own relevant pages.
 

--- a/docssrc/src/argument_entities.md
+++ b/docssrc/src/argument_entities.md
@@ -4,7 +4,7 @@
 
 ![An image of an entity selector argument with a list of suggestions including entity selectors and a player name](./images/arguments/entityselector.png)
 
-Minecraft's [target selectors](https://minecraft.gamepedia.com/Commands#Target_selectors) (e.g. `@a` or `@e`) are implemented using the subclasses of the `EntitySelectorArgument` class. This allows you to select specific entities based on certain attributes.
+Minecraft's [target selectors](https://minecraft.wiki/w/Commands#Target_selectors) (e.g. `@a` or `@e`) are implemented using the subclasses of the `EntitySelectorArgument` class. This allows you to select specific entities based on certain attributes.
 
 There are four `EntitySelectorArgument` subclasses that determine what type of data to return:
 

--- a/docssrc/src/argument_itemstackpredicate.md
+++ b/docssrc/src/argument_itemstackpredicate.md
@@ -1,6 +1,6 @@
 # ItemStack predicate arguments
 
-Similar to the `BlockPredicateArgument`, the `ItemStackPredicateArgument` is a way of performing predicate checks on `ItemStack` objects. These can represent tags, such as the ones declared [here on the MinecraftWiki](https://minecraft.gamepedia.com/Tag#Items), or individual items. The cast type for this argument is `Predicate<ItemStack>`.
+Similar to the `BlockPredicateArgument`, the `ItemStackPredicateArgument` is a way of performing predicate checks on `ItemStack` objects. These can represent tags, such as the ones declared [here on the MinecraftWiki](https://minecraft.wiki/w/Tag#Items), or individual items. The cast type for this argument is `Predicate<ItemStack>`.
 
 <div class="example">
 

--- a/docssrc/src/argument_namespacedkey.md
+++ b/docssrc/src/argument_namespacedkey.md
@@ -1,5 +1,5 @@
 # NamespacedKey arguments
 
-NamespacedKey arguments represent Minecraft's [resource locations](https://minecraft.fandom.com/wiki/Resource_location), or namespaced keys. This argument is casted to Bukkit's `NamespacedKey` object.
+NamespacedKey arguments represent Minecraft's [resource locations](https://minecraft.wiki/w/Resource_location), or namespaced keys. This argument is casted to Bukkit's `NamespacedKey` object.
 
 Namespaced keys are typically of the form `namespace:key`. If no namespace is provided, the default namespace (`minecraft`) will be used.

--- a/docssrc/src/argument_particle.md
+++ b/docssrc/src/argument_particle.md
@@ -19,7 +19,7 @@ The `T data` can be used in Bukkit's `World.spawnParticle(Particle particle, Loc
 
 ## Particle data
 
-The particle argument requires additional data for a particle depending on what the particle is. Information about this can be found [on the Argument types page on the MinecraftWiki](https://minecraft.fandom.com/wiki/Argument_types#particle). The following particles have additional data required to display them:
+The particle argument requires additional data for a particle depending on what the particle is. Information about this can be found [on the Argument types page on the MinecraftWiki](https://minecraft.wiki/w/Argument_types#particle). The following particles have additional data required to display them:
 
 | Bukkit Particle         | Minecraft particle      | Arguments                                                             |
 |-------------------------|-------------------------|-----------------------------------------------------------------------|

--- a/docssrc/src/argument_scoreboards.md
+++ b/docssrc/src/argument_scoreboards.md
@@ -2,8 +2,8 @@
 
 The CommandAPI uses two classes to provide information about a scoreboard:
 
-- The `ScoreHolderArgument` class represents **score holder** - a player's name or an entity's UUID that has scores in an objective. This is described in more detail [on the Minecraft Wiki](https://minecraft.gamepedia.com/Scoreboard#Objectives).
-- The `ScoreboardSlotArgument` class represents a **display slot** (sidebar, list or belowName) as well as the team color if the display is the sidebar. This is described in more detail [on the Minecraft Wiki](https://minecraft.gamepedia.com/Scoreboard#Display_slots).
+- The `ScoreHolderArgument` class represents **score holder** - a player's name or an entity's UUID that has scores in an objective. This is described in more detail [on the Minecraft Wiki](https://minecraft.wiki/w/Scoreboard#Objectives).
+- The `ScoreboardSlotArgument` class represents a **display slot** (sidebar, list or belowName) as well as the team color if the display is the sidebar. This is described in more detail [on the Minecraft Wiki](https://minecraft.wiki/w/Scoreboard#Display_slots).
 
 -----
 

--- a/docssrc/src/conversionentityselectors.md
+++ b/docssrc/src/conversionentityselectors.md
@@ -1,6 +1,6 @@
 # Entity selectors
 
-[Entity selectors](https://minecraft.fandom.com/wiki/Target_selectors) (also known as target selectors) allows you to select certain entities or players which fit a certain criteria when writing a command. Typically, these are of the form `@p`, `@r`, `@a`, `@e` or `@s`. By default, when converting a command without arguments, the CommandAPI will not handle these entity selectors. In order to get entity selectors to cooperate with plugins, they must be declared in the relevant `config.yml` section.
+[Entity selectors](https://minecraft.wiki/w/Target_selectors) (also known as target selectors) allows you to select certain entities or players which fit a certain criteria when writing a command. Typically, these are of the form `@p`, `@r`, `@a`, `@e` or `@s`. By default, when converting a command without arguments, the CommandAPI will not handle these entity selectors. In order to get entity selectors to cooperate with plugins, they must be declared in the relevant `config.yml` section.
 
 <div class="example">
 

--- a/docssrc/src/conversionforownerssingleargs.md
+++ b/docssrc/src/conversionforownerssingleargs.md
@@ -138,7 +138,7 @@ To declare a value \\(x\\) that can take any range of values and is a decimal nu
 
 ## List of all supported argument types
 
-The list of types are based on [the list of argument types from the Minecraft Wiki](https://minecraft.gamepedia.com/Argument_types), with a few changes. The complete list that the CommandAPI supports is as follows:
+The list of types are based on [the list of argument types from the Minecraft Wiki](https://minecraft.wiki/w/Argument_types), with a few changes. The complete list that the CommandAPI supports is as follows:
 
 | Type                           | Description                                                  |
 | ------------------------------ | ------------------------------------------------------------ |

--- a/docssrc/src/functions.md
+++ b/docssrc/src/functions.md
@@ -1,6 +1,6 @@
 # Functions
 
-The CommandAPI has support to use Minecraft's [functions](https://minecraft.gamepedia.com/Function_(Java_Edition)) within your plugins. This is handled by using a class provided by the CommandAPI called `FunctionWrapper`, which allows you to execute functions. The CommandAPI also provides support to let you run your own commands within Minecraft function files.
+The CommandAPI has support to use Minecraft's [functions](https://minecraft.wiki/w/Function_(Java_Edition)) within your plugins. This is handled by using a class provided by the CommandAPI called `FunctionWrapper`, which allows you to execute functions. The CommandAPI also provides support to let you run your own commands within Minecraft function files.
 
 -----
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: <https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom>. This PR updates all the URLs to the new domain: minecraft.wiki