### PR TITLE
Fix 'advenure' typos

### DIFF
--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/BukkitTooltip.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/BukkitTooltip.java
@@ -83,31 +83,31 @@ public class BukkitTooltip<S> extends Tooltip<S> {
 	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
 	 * @param suggestions array of suggestions to provide to the user
 	 *
-     * @deprecated This method has been deprecated in favour of {@link BukkitTooltip#generateAdventureComponents(Function, Object[])}
+	 * @deprecated This method has been deprecated in favour of {@link BukkitTooltip#generateAdventureComponents(Function, Object[])}
 	 * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
 	 * 	tooltips
 	 */
-    @Deprecated(forRemoval = true)
+	@Deprecated(forRemoval = true, since = "9.3.0")
 	@SafeVarargs
 	public static <S> Collection<Tooltip<S>> generateAdvenureComponents(Function<S, Component> tooltipGenerator, S... suggestions) {
 		return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
 	}
 
-    /**
-     * Constructs a collection of {@link Tooltip <S>} objects from an array of suggestions, and a function which generates a
-     * tooltip formatted as an adventure {@link Component} for each suggestion
-     *
-     * @param <S> the object that the argument suggestions use
-     * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
-     * @param suggestions array of suggestions to provide to the user
-     *
-     * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
-     * 	tooltips
-     */
-    @SafeVarargs
-    public static <S> Collection<Tooltip<S>> generateAdventureComponents(Function<S, Component> tooltipGenerator, S... suggestions) {
-        return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
-    }
+	/**
+	 * Constructs a collection of {@link Tooltip <S>} objects from an array of suggestions, and a function which generates a
+	 * tooltip formatted as an adventure {@link Component} for each suggestion
+	 *
+	 * @param <S> the object that the argument suggestions use
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
+	 * @param suggestions array of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
+	 */
+	@SafeVarargs
+	public static <S> Collection<Tooltip<S>> generateAdventureComponents(Function<S, Component> tooltipGenerator, S... suggestions) {
+		return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
+	}
 
 	/**
 	 * Constructs a collection of {@link Tooltip <S>} objects from a collection of suggestions, and a function which generates a
@@ -117,28 +117,29 @@ public class BukkitTooltip<S> extends Tooltip<S> {
 	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
 	 * @param suggestions collection of suggestions to provide to the user
 	 *
-     * @deprecated This method has been deprecated in favour of {@link BukkitTooltip#generateAdventureComponents(Function, Collection)}
+	 * @deprecated This method has been deprecated in favour of {@link BukkitTooltip#generateAdventureComponents(Function, Collection)}
 	 * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
 	 * 	tooltips
 	 */
+	@Deprecated(forRemoval = true, since = "9.3.0")
 	public static <S> Collection<Tooltip<S>> generateAdvenureComponents(Function<S, Component> tooltipGenerator, Collection<S> suggestions) {
 		return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
 	}
 
-    /**
-     * Constructs a collection of {@link Tooltip <S>} objects from a collection of suggestions, and a function which generates a
-     * tooltip formatted as an adventure {@link Component} for each suggestion
-     *
-     * @param <S> the object that the argument suggestions use
-     * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
-     * @param suggestions collection of suggestions to provide to the user
-     *
-     * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
-     * 	tooltips
-     */
-    public static <S> Collection<Tooltip<S>> generateAdventureComponents(Function<S, Component> tooltipGenerator, Collection<S> suggestions) {
-        return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
-    }
+	/**
+	 * Constructs a collection of {@link Tooltip <S>} objects from a collection of suggestions, and a function which generates a
+	 * tooltip formatted as an adventure {@link Component} for each suggestion
+	 *
+	 * @param <S> the object that the argument suggestions use
+	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
+	 * @param suggestions collection of suggestions to provide to the user
+	 *
+	 * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
+	 * 	tooltips
+	 */
+	public static <S> Collection<Tooltip<S>> generateAdventureComponents(Function<S, Component> tooltipGenerator, Collection<S> suggestions) {
+		return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
+	}
 
 	/**
 	 * Constructs a <code>BukkitTooltip&lt;S&gt;</code> with a suggestion and a formatted tooltip

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/BukkitTooltip.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/BukkitTooltip.java
@@ -83,13 +83,31 @@ public class BukkitTooltip<S> extends Tooltip<S> {
 	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
 	 * @param suggestions array of suggestions to provide to the user
 	 *
+     * @deprecated This method has been deprecated in favour of {@link BukkitTooltip#generateAdventureComponents(Function, Object[])}
 	 * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
 	 * 	tooltips
 	 */
+    @Deprecated(forRemoval = true)
 	@SafeVarargs
 	public static <S> Collection<Tooltip<S>> generateAdvenureComponents(Function<S, Component> tooltipGenerator, S... suggestions) {
 		return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
 	}
+
+    /**
+     * Constructs a collection of {@link Tooltip <S>} objects from an array of suggestions, and a function which generates a
+     * tooltip formatted as an adventure {@link Component} for each suggestion
+     *
+     * @param <S> the object that the argument suggestions use
+     * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
+     * @param suggestions array of suggestions to provide to the user
+     *
+     * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
+     * 	tooltips
+     */
+    @SafeVarargs
+    public static <S> Collection<Tooltip<S>> generateAdventureComponents(Function<S, Component> tooltipGenerator, S... suggestions) {
+        return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
+    }
 
 	/**
 	 * Constructs a collection of {@link Tooltip <S>} objects from a collection of suggestions, and a function which generates a
@@ -99,12 +117,28 @@ public class BukkitTooltip<S> extends Tooltip<S> {
 	 * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
 	 * @param suggestions collection of suggestions to provide to the user
 	 *
+     * @deprecated This method has been deprecated in favour of {@link BukkitTooltip#generateAdventureComponents(Function, Collection)}
 	 * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
 	 * 	tooltips
 	 */
 	public static <S> Collection<Tooltip<S>> generateAdvenureComponents(Function<S, Component> tooltipGenerator, Collection<S> suggestions) {
 		return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
 	}
+
+    /**
+     * Constructs a collection of {@link Tooltip <S>} objects from a collection of suggestions, and a function which generates a
+     * tooltip formatted as an adventure {@link Component} for each suggestion
+     *
+     * @param <S> the object that the argument suggestions use
+     * @param tooltipGenerator function which returns a formatted tooltip for the suggestion, an adventure {@link Component}
+     * @param suggestions collection of suggestions to provide to the user
+     *
+     * @return a collection of {@link Tooltip <S>} objects from the provided suggestions, with the generated formatted
+     * 	tooltips
+     */
+    public static <S> Collection<Tooltip<S>> generateAdventureComponents(Function<S, Component> tooltipGenerator, Collection<S> suggestions) {
+        return generate(tooltipGenerator, BukkitTooltip::ofAdventureComponent, suggestions);
+    }
 
 	/**
 	 * Constructs a <code>BukkitTooltip&lt;S&gt;</code> with a suggestion and a formatted tooltip

--- a/docssrc/src/upgrading.md
+++ b/docssrc/src/upgrading.md
@@ -1,5 +1,27 @@
 # Upgrading guide
 
+## From 9.2.0 to 9.3.0
+
+The `BukkitTooltip.generateAdvenureComponents` methods have now been deprecated in favour of the correctly named `BukkitTooltip.generateAdventureComponents` methods:
+
+<div class="multi-pre">
+
+```java,9.2.0
+BukkitTooltip.generateAdvenureComponents()
+```
+
+</div>
+
+$$\downarrow$$
+
+<div class="multi-pre">
+
+```java,9.3.0
+BukkitTooltip.generateAdventureComponents()
+```
+
+</div>
+
 ## From 9.0.3 to 9.1.0
 
 ### MultiLiteralArgument changes


### PR DESCRIPTION
Not sure if I need to put `since = "..."`