### PR TITLE
Run command tree modify tasks with `Commands.COMMAND_SENDING_POOL` on Paper

### DIFF
--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -467,48 +467,50 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 	@Override
 	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes) {
 		if(!CommandAPI.canRegister()) {
-			// Usually, when registering commands during server startup, we can just put our commands into the
-			// `net.minecraft.server.MinecraftServer#vanillaCommandDispatcher` and leave it. As the server finishes setup,
-			// it and the CommandAPI do some extra stuff to make everything work, and we move on.
-			// So, if we want to register commands while the server is running, we need to do all that extra stuff, and
-			// that is what this code does.
-			// We could probably call all those methods to sync everything up, but in the spirit of avoiding side effects
-			// and avoiding doing things twice for existing commands, this is a distilled version of those methods.
+			paper.modifyCommandTreesSafely(() -> {
+				// Usually, when registering commands during server startup, we can just put our commands into the
+				// `net.minecraft.server.MinecraftServer#vanillaCommandDispatcher` and leave it. As the server finishes setup,
+				// it and the CommandAPI do some extra stuff to make everything work, and we move on.
+				// So, if we want to register commands while the server is running, we need to do all that extra stuff, and
+				// that is what this code does.
+				// We could probably call all those methods to sync everything up, but in the spirit of avoiding side effects
+				// and avoiding doing things twice for existing commands, this is a distilled version of those methods.
 
-			CommandMap map = paper.getCommandMap();
-			String permNode = unpackInternalPermissionNodeString(registeredCommand.permission());
-			RootCommandNode<Source> root = getResourcesDispatcher().getRoot();
+				CommandMap map = paper.getCommandMap();
+				String permNode = unpackInternalPermissionNodeString(registeredCommand.permission());
+				RootCommandNode<Source> root = getResourcesDispatcher().getRoot();
 
-			// Wrapping Brigadier nodes into VanillaCommandWrappers and putting them in the CommandMap usually happens
-			// in `CraftServer#setVanillaCommands`
-			Command command = wrapToVanillaCommandWrapper(resultantNode);
-			map.register("minecraft", command);
-
-			// Adding permissions to these Commands usually happens in `CommandAPIBukkit#onEnable`
-			command.setPermission(permNode);
-
-			// Adding commands to the other (Why bukkit/spigot?!) dispatcher usually happens in `CraftServer#syncCommands`
-			root.addChild(resultantNode);
-			root.addChild(namespaceNode(resultantNode));
-
-			// Do the same for the aliases
-			for(LiteralCommandNode<Source> node: aliasNodes) {
-				command = wrapToVanillaCommandWrapper(node);
+				// Wrapping Brigadier nodes into VanillaCommandWrappers and putting them in the CommandMap usually happens
+				// in `CraftServer#setVanillaCommands`
+				Command command = wrapToVanillaCommandWrapper(resultantNode);
 				map.register("minecraft", command);
 
+				// Adding permissions to these Commands usually happens in `CommandAPIBukkit#onEnable`
 				command.setPermission(permNode);
 
-				root.addChild(node);
-				root.addChild(namespaceNode(node));
-			}
+				// Adding commands to the other (Why bukkit/spigot?!) dispatcher usually happens in `CraftServer#syncCommands`
+				root.addChild(resultantNode);
+				root.addChild(namespaceNode(resultantNode));
 
-			// Adding the command to the help map usually happens in `CommandAPIBukkit#onEnable`
-			updateHelpForCommands(List.of(registeredCommand));
+				// Do the same for the aliases
+				for (LiteralCommandNode<Source> node : aliasNodes) {
+					command = wrapToVanillaCommandWrapper(node);
+					map.register("minecraft", command);
 
-			// Sending command dispatcher packets usually happens when Players join the server
-			for(Player p: Bukkit.getOnlinePlayers()) {
-				p.updateCommands();
-			}
+					command.setPermission(permNode);
+
+					root.addChild(node);
+					root.addChild(namespaceNode(node));
+				}
+
+				// Adding the command to the help map usually happens in `CommandAPIBukkit#onEnable`
+				updateHelpForCommands(List.of(registeredCommand));
+
+				// Sending command dispatcher packets usually happens when Players join the server
+				for (Player p : Bukkit.getOnlinePlayers()) {
+					p.updateCommands();
+				}
+			});
 		}
 	}
 
@@ -531,7 +533,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 	@Override
 	public LiteralCommandNode<Source> registerCommandNode(LiteralArgumentBuilder<Source> node) {
-		return getBrigadierDispatcher().register(node);
+		return paper.modifyCommandTreesSafely(() -> getBrigadierDispatcher().register(node));
 	}
 
 	@Override
@@ -558,52 +560,54 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 	}
 
 	private void unregisterInternal(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit) {
-		CommandAPI.logInfo("Unregistering command /" + commandName);
+		paper.modifyCommandTreesSafely(() -> {
+			CommandAPI.logInfo("Unregistering command /" + commandName);
 
-		if(!unregisterBukkit) {
-			// Remove nodes from the Vanilla dispatcher
-			// This dispatcher doesn't usually have namespaced version of commands (those are created when commands
-			//  are transferred to Bukkit's CommandMap), but if they ask, we'll do it
-			removeBrigadierCommands(getBrigadierDispatcher(), commandName, unregisterNamespaces, c -> true);
+			if (!unregisterBukkit) {
+				// Remove nodes from the Vanilla dispatcher
+				// This dispatcher doesn't usually have namespaced version of commands (those are created when commands
+				//  are transferred to Bukkit's CommandMap), but if they ask, we'll do it
+				removeBrigadierCommands(getBrigadierDispatcher(), commandName, unregisterNamespaces, c -> true);
 
-			// Update the dispatcher file
-			CommandAPIHandler.getInstance().writeDispatcherToFile();
-		}
-
-		if(unregisterBukkit || !CommandAPI.canRegister()) {
-			// We need to remove commands from Bukkit's CommandMap if we're unregistering a Bukkit command, or
-			//  if we're unregistering after the server is enabled, because `CraftServer#setVanillaCommands` will have
-			//  moved the Vanilla command into the CommandMap
-			Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) paper.getCommandMap());
-
-			// If we are unregistering a Bukkit command, DO NOT unregister VanillaCommandWrappers
-			// If we are unregistering a Vanilla command, ONLY unregister VanillaCommandWrappers
-			boolean isMainVanilla = isVanillaCommandWrapper(knownCommands.get(commandName));
-			if(unregisterBukkit ^ isMainVanilla) knownCommands.remove(commandName);
-
-			if(unregisterNamespaces) {
-				removeCommandNamespace(knownCommands, commandName, c -> unregisterBukkit ^ isVanillaCommandWrapper(c));
+				// Update the dispatcher file
+				CommandAPIHandler.getInstance().writeDispatcherToFile();
 			}
-		}
 
-		if(!CommandAPI.canRegister()) {
-			// If the server is enabled, we have extra cleanup to do
+			if (unregisterBukkit || !CommandAPI.canRegister()) {
+				// We need to remove commands from Bukkit's CommandMap if we're unregistering a Bukkit command, or
+				//  if we're unregistering after the server is enabled, because `CraftServer#setVanillaCommands` will have
+				//  moved the Vanilla command into the CommandMap
+				Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) paper.getCommandMap());
 
-			// Remove commands from the resources dispatcher
-			// If we are unregistering a Bukkit command, ONLY unregister BukkitCommandWrappers
-			// If we are unregistering a Vanilla command, DO NOT unregister BukkitCommandWrappers
-			removeBrigadierCommands(getResourcesDispatcher(), commandName, unregisterNamespaces,
-				c -> !unregisterBukkit ^ isBukkitCommandWrapper(c));
+				// If we are unregistering a Bukkit command, DO NOT unregister VanillaCommandWrappers
+				// If we are unregistering a Vanilla command, ONLY unregister VanillaCommandWrappers
+				boolean isMainVanilla = isVanillaCommandWrapper(knownCommands.get(commandName));
+				if (unregisterBukkit ^ isMainVanilla) knownCommands.remove(commandName);
 
-			// Help topics (from Bukkit and CommandAPI) are only setup after plugins enable, so we only need to worry
-			//  about removing them once the server is loaded.
-			getHelpMap().remove("/" + commandName);
-
-			// Notify players
-			for (Player p : Bukkit.getOnlinePlayers()) {
-				p.updateCommands();
+				if (unregisterNamespaces) {
+					removeCommandNamespace(knownCommands, commandName, c -> unregisterBukkit ^ isVanillaCommandWrapper(c));
+				}
 			}
-		}
+
+			if (!CommandAPI.canRegister()) {
+				// If the server is enabled, we have extra cleanup to do
+
+				// Remove commands from the resources dispatcher
+				// If we are unregistering a Bukkit command, ONLY unregister BukkitCommandWrappers
+				// If we are unregistering a Vanilla command, DO NOT unregister BukkitCommandWrappers
+				removeBrigadierCommands(getResourcesDispatcher(), commandName, unregisterNamespaces,
+					c -> !unregisterBukkit ^ isBukkitCommandWrapper(c));
+
+				// Help topics (from Bukkit and CommandAPI) are only setup after plugins enable, so we only need to worry
+				//  about removing them once the server is loaded.
+				getHelpMap().remove("/" + commandName);
+
+				// Notify players
+				for (Player p : Bukkit.getOnlinePlayers()) {
+					p.updateCommands();
+				}
+			}
+		});
 	}
 
 	private void removeBrigadierCommands(CommandDispatcher<Source> dispatcher, String commandName,

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
@@ -402,6 +402,11 @@ public interface NMS<CommandListenerWrapper> {
 	CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher();
 
 	/**
+	 * @return The class object representing {@code net.minecraft.commands.Commands} (or equivalent mapped class).
+	 */
+	Class<?> getNMSCommandsClass();
+
+	/**
 	 * Returns the Server's internal (OBC) CommandMap
 	 * 
 	 * @return A SimpleCommandMap from the OBC server

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.15/src/main/java/dev/jorel/commandapi/nms/NMS_1_15.java
@@ -520,6 +520,11 @@ public class NMS_1_15 extends NMSWrapper_1_15 {
 	}
 
 	@Override
+	public Class<?> getNMSCommandsClass() {
+		return net.minecraft.server.v1_15_R1.CommandDispatcher.class;
+	}
+
+	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
@@ -543,6 +543,11 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 	}
 
 	@Override
+	public Class<?> getNMSCommandsClass() {
+		return net.minecraft.server.v1_16_R1.CommandDispatcher.class;
+	}
+
+	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
@@ -541,6 +541,11 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 	}
 
 	@Override
+	public Class<?> getNMSCommandsClass() {
+		return net.minecraft.server.v1_16_R2.CommandDispatcher.class;
+	}
+
+	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
@@ -497,6 +497,11 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 	}
 
 	@Override
+	public Class<?> getNMSCommandsClass() {
+		return net.minecraft.server.v1_16_R3.CommandDispatcher.class;
+	}
+
+	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
@@ -373,6 +373,11 @@ public abstract class NMS_Common extends CommandAPIBukkit<CommandSourceStack> {
 	public abstract CommandDispatcher<CommandSourceStack> getResourcesDispatcher();
 
 	@Override
+	public Class<?> getNMSCommandsClass() {
+		return net.minecraft.commands.Commands.class;
+	}
+
+	@Override
 	public final BaseComponent[] getChat(CommandContext<CommandSourceStack> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(Serializer.toJson(MessageArgument.getMessage(cmdCtx, key)));
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
@@ -77,6 +77,14 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 	}
 
 	@Override
+	public Class<?> getNMSCommandsClass() {
+		// This is currently only used by PaperImplementations to access a Paper-specific nms field
+		//  MockBukkit does not simulate a Paper server, so this field never exists in testing anyway
+		//  So, just return a class that doesn't have the field, and this works equivalently to a Spigot server
+		return Object.class;
+	}
+
+	@Override
 	public final BukkitCommandSender<? extends CommandSender> getSenderForCommand(CommandContext<CLW> cmdCtx, boolean forceNative) {
 		return getCommandSenderFromCommandSource(cmdCtx.getSource());
 	}


### PR DESCRIPTION
This PR fixes #494

https://github.com/PaperMC/Paper/pull/3116 added a [patch](https://github.com/PaperMC/Paper/blob/4b0bc74c90582f2d52d720c795228130545cd103/patches/server/0294-Async-command-map-building.patch) to Paper that causes the [Commands](https://wiki.vg/Protocol#Commands) packet to be built asynchronously. Specifically, they added the following [`ThreadPoolExector`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html) to the `net.minecraft.commands.Commands` class and used it to move some of the work off the main thread.

```java
public static final java.util.concurrent.ThreadPoolExecutor COMMAND_SENDING_POOL = new java.util.concurrent.ThreadPoolExecutor(
    0, 2, 60L, java.util.concurrent.TimeUnit.SECONDS,
    new java.util.concurrent.LinkedBlockingQueue<>(),
    new com.google.common.util.concurrent.ThreadFactoryBuilder()
        .setNameFormat("Paper Async Command Builder Thread Pool - %1$d")
        .setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER))
        .build(),
    new java.util.concurrent.ThreadPoolExecutor.DiscardPolicy()
);
```

Previously, if this thread pool happened to be looping through the Brigadier Vanilla or Resources CommandDispatcher and the CommandAPI registered or unregistered a command, a `ConcurrentModificationException` could occur.

This PR fixes this by adding a `modifyCommandTreesSafely` method to `PaperImplementations`. Anytime CommandAPIBukkit needs to modify the command trees, it calls this method. If the `COMMAND_SENDING_POOL` is present, the modification task will be submitted to the pool, and the current thread will be blocked until the task is completed. If the thread pool is not present, the task is run immediately like before.

 ---

I chose this solution because I noticed that the `COMMAND_SENDING_POOL` seemed to only run one task at a time. So, if you put the modify task into the pool, you can ensure that the pool isn't running another task, and no CME occurs. 

However, the fact that the pool only ran one task at a time struck me as odd. The javadocs for the `ThreadPoolExecutor` constructor indicate the second parameter — `2` — is the maximum number of threads allowed in the pool. Therefore, I expected that at most 2 tasks could be run at the same time in this pool, potentially allowing a modify task **and** a command build task to run at the same time, causing a CME.

In practice, I only saw this pool running at most 1 task. I don't really understand what's going on, so it seems possible that this PR could actually not solve the problem.

I think a better solution would be for `PaperImplementations#modifyCommandTreesSafely` to block the thread until the `COMMAND_SENDING_POOL` has finished all its tasks. However, I didn't see any way to do this without controlling how tasks are submitted to the pool.

Anyway, I am definitely not familiar with multithreaded code, so I have no idea if what I've done here is a 'good' solution. I'm not sure if I'm submitting tasks correctly or handling stuff like `InterruptedException` safely. Feedback is greatly appreciated.

---

So far, I've tested this manually on Paper and Spigot 1.20.2. It seems to resolve all the issues mentioned in #494. I plan to test this on other versions as well.

TODO:
- Test on real servers (Paper+Spigot)
  - [ ] 1.15, 1.15.1, 1.15.2
  - [ ] 1.16.1
  - [ ] 1.16.2, 1.16.3
  - [ ] 1.16.4
  - [ ] 1.16.5
  - [ ] 1.17
  - [ ] 1.17.1
  - [ ] 1.18, 1.18.1
  - [ ] 1.18.2
  - [ ] 1.19
  - [ ] 1.19.1, 1.19.2
  - [ ] 1.19.3
  - [ ] 1.19.4
  - [ ] 1.20, 1.20.1
  - [ ] 1.20.2
