### PR TITLE
Typo fix in Command registration

### DIFF
--- a/docssrc/src/commandregistration.md
+++ b/docssrc/src/commandregistration.md
@@ -18,7 +18,7 @@ I think the easiest way to explain it is with an example:
 
 - First, we create a new `CommandAPICommand`, with the name of the command that the sender must enter to run it.
 
-- When, we create an argument to add to the command using `withArguments`. This is described in more detail in [the section on arguments](./arguments.html).
+- Then, we create an argument to add to the command using `withArguments`. This is described in more detail in [the section on arguments](./arguments.html).
 
 - In this example, we add an alias, "broadcast", to the command. This allows the sender to use either `/broadcastmsg <message>` or `/broadcast <message>`.
 


### PR DESCRIPTION
Fixing the small typo: **`When`**`, we create...` to **`Then`**`, we create...`
![image](https://github.com/JorelAli/CommandAPI/assets/56084910/02356479-e68e-4c4a-95d7-cfd71e013d43)
