### PR TITLE
Updates help generation for literal arguments

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIHandler.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIHandler.java
@@ -615,10 +615,12 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 		}
 
 		List<String> argumentsString = new ArrayList<>();
+		List<AbstractArgument<?, ?, ?, ?>> arguments = new ArrayList<>();
 		for (Argument arg : args) {
+			arguments.add(arg);
 			argumentsString.add(arg.getNodeName() + ":" + arg.getClass().getSimpleName());
 		}
-		RegisteredCommand registeredCommandInformation = new RegisteredCommand(commandName, argumentsString, shortDescription,
+		RegisteredCommand registeredCommandInformation = new RegisteredCommand(commandName, argumentsString, List.copyOf(arguments), shortDescription,
 			fullDescription, usageDescription, aliases, permission, namespace);
 		registeredCommands.add(registeredCommandInformation);
 

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/RegisteredCommand.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/RegisteredCommand.java
@@ -1,5 +1,7 @@
 package dev.jorel.commandapi;
 
+import dev.jorel.commandapi.arguments.AbstractArgument;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -25,6 +27,11 @@ public record RegisteredCommand(
 	 *         {@code value:}{@link IntegerArgument}
 	 */
 	List<String> argsAsStr,
+
+	/**
+	 * @return An unmodifiable list of arguments for this command
+	 */
+	List<AbstractArgument<?, ?, ?, ?>> arguments,
 
 	/**
 	 * @return An {@link Optional} containing this command's help's short

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/AbstractArgument.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/AbstractArgument.java
@@ -361,6 +361,10 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 		this.withPermission(argument.getArgumentPermission());
 	}
 
+	public String getAsArgumentString() {
+		return "<" + this.getNodeName() + ">";
+	}
+
 	@Override
 	public String toString() {
 		return this.getNodeName() + "<" + this.getClass().getSimpleName() + ">";

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -13,6 +13,7 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import dev.jorel.commandapi.arguments.AbstractArgument;
 import dev.jorel.commandapi.commandsenders.*;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -315,8 +316,8 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 				final RegisteredCommand command = commandsWithIdenticalNames.get(i);
 				StringBuilder usageString = new StringBuilder();
 				usageString.append("/").append(command.commandName()).append(" ");
-				for (String arg : command.argsAsStr()) {
-					usageString.append("<").append(arg.split(":")[0]).append("> ");
+				for (AbstractArgument<?, ?, ?, ?> arg : command.arguments()) {
+					usageString.append(arg.getAsArgumentString()).append(" ");
 				}
 				usages[i] = usageString.toString().trim();
 			}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/arguments/LiteralArgument.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/arguments/LiteralArgument.java
@@ -138,6 +138,11 @@ public class LiteralArgument extends Argument<String> implements Literal<Argumen
 	}
 
 	@Override
+	public String getAsArgumentString() {
+		return literal;
+	}
+
+	@Override
 	public <Source> String parseArgument(CommandContext<Source> cmdCtx, String key, CommandArguments previousArgs) throws CommandSyntaxException {
 		return literal;
 	}

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/arguments/LiteralArgument.java
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/arguments/LiteralArgument.java
@@ -134,6 +134,11 @@ public class LiteralArgument extends Argument<String> implements Literal<Argumen
 	}
 
 	@Override
+	public String getAsArgumentString() {
+		return literal;
+	}
+
+	@Override
 	public <Source> String parseArgument(CommandContext<Source> cmdCtx, String key, CommandArguments previousArgs) throws CommandSyntaxException {
 		return literal;
 	}


### PR DESCRIPTION
For #536
Now displays the literal value instead of the node name