### PR TITLE
Fix help topic generation

### DIFF
--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -299,6 +299,10 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		return (Bukkit.getPluginCommand(command) == null ? "/" : "/minecraft:") + command;
 	}
 
+	private String generateCommandHelpPrefix(String command, String namespace) {
+		return (Bukkit.getPluginCommand(command) == null ? "/" + namespace + ":" : "/minecraft:") + command;
+	}
+
 	private void generateHelpUsage(StringBuilder sb, RegisteredCommand command) {
 		// Generate usages
 		String[] usages = getUsageList(command);
@@ -361,8 +365,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 			String commandPrefix = generateCommandHelpPrefix(command.commandName());
 
 			// Namespaced commands shouldn't have a help topic, we should save the namespaced command name
-			commandPrefix = commandPrefix.substring(1); // Get rid of the '/' for the namespaced command
-			namespacedCommandNames.add("/" + command.namespace() + ":" + commandPrefix); // Bukkit it stupid, it registers commands with a '/' in the help map
+			namespacedCommandNames.add(generateCommandHelpPrefix(command.commandName(), command.namespace()));
 			
 			StringBuilder aliasSb = new StringBuilder();
 			final String shortDescription;
@@ -426,8 +429,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 					helpTopic = generateHelpTopic(commandPrefix, shortDescription, currentAliasSb.toString().trim(), permission);
 
 					// Namespaced commands shouldn't have a help topic, we should save the namespaced alias name
-					commandPrefix = commandPrefix.substring(1); // Get rid of the '/' for the namespaced command
-					namespacedCommandNames.add("/" + command.namespace() + ":" + commandPrefix); // Bukkit it stupid, it registers commands with a '/' in the help map
+					namespacedCommandNames.add(generateCommandHelpPrefix(alias, command.namespace()));
 				}
 				helpTopicsToAdd.put(commandPrefix, helpTopic);
 			}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -358,7 +358,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 	void updateHelpForCommands(List<RegisteredCommand> commands) {
 		Map<String, HelpTopic> helpTopicsToAdd = new HashMap<>();
-		List<String> namespacedCommandNames = new ArrayList<>();
+		Set<String> namespacedCommandNames = new HashSet<>();
 
 		for (RegisteredCommand command : commands) {
 			// Don't override the plugin help topic

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -360,7 +360,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 			// Don't override the plugin help topic
 			String commandPrefix = generateCommandHelpPrefix(command.commandName());
 
-			// Namespaced commands shouldn't have a namespace, we should save the namespaced command name
+			// Namespaced commands shouldn't have a help topic, we should save the namespaced command name
 			commandPrefix = commandPrefix.substring(1); // Get rid of the '/' for the namespaced command
 			namespacedCommandNames.add("/" + command.namespace() + ":" + commandPrefix); // Bukkit it stupid, it registers commands with a '/' in the help map
 			
@@ -425,7 +425,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 					commandPrefix = generateCommandHelpPrefix(alias);
 					helpTopic = generateHelpTopic(commandPrefix, shortDescription, currentAliasSb.toString().trim(), permission);
 
-					// Namespaced commands shouldn't have a namespace, we should save the namespaced command name
+					// Namespaced commands shouldn't have a help topic, we should save the namespaced alias name
 					commandPrefix = commandPrefix.substring(1); // Get rid of the '/' for the namespaced command
 					namespacedCommandNames.add("/" + command.namespace() + ":" + commandPrefix); // Bukkit it stupid, it registers commands with a '/' in the help map
 				}


### PR DESCRIPTION
The basic thing works, just a few more things need checking:
- [x] ~~Figure out if this has been introduced by #509 or if this was a thing before. I did not check this when opening #538~~ Technically, namespaces having a help entry might actually be considered a bug since a command with the `minecraft:` namespace didn't have a help entry before the current snapshot phase.
- [x] ~~Alias generation currently is stupid for namespaced versions of a command~~ Nope, it isn't. See above.
- [x] ~~Should the usage generation be updated again to display the namespaced version of a command?~~ Not necessary, the namespaced version having a help topic is a bug introduced by #509 