### PR TITLE
Hotfix CommandAPI throwing errors because of Paper's Brigadier command API

### DIFF
--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
@@ -210,6 +210,7 @@ public class NMS_1_20_R4 extends NMS_Common {
 	private static final Field entitySelectorUsesSelector;
 	// private static final SafeVarHandle<ItemInput, CompoundTag> itemInput;
 	private static final Field serverFunctionLibraryDispatcher;
+	private static final Field vanillaCommandDispatcher;
 
 	// Derived from net.minecraft.commands.Commands;
 	private static final CommandBuildContext COMMAND_BUILD_CONTEXT;
@@ -230,6 +231,13 @@ public class NMS_1_20_R4 extends NMS_Common {
 		// itemInput = SafeVarHandle.ofOrNull(ItemInput.class, "c", "tag", CompoundTag.class);
 		// For some reason, MethodHandles fails for this field, but Field works okay
 		serverFunctionLibraryDispatcher = CommandAPIHandler.getField(ServerFunctionLibrary.class, "g", "dispatcher");
+		Field commandDispatcher;
+		try {
+			commandDispatcher = MinecraftServer.class.getDeclaredField("vanillaCommandDispatcher");
+		} catch (NoSuchFieldException | SecurityException e) {
+			commandDispatcher = null;
+		}
+		vanillaCommandDispatcher = commandDispatcher;
 	}
 
 	private static NamespacedKey fromResourceLocation(ResourceLocation key) {
@@ -895,7 +903,11 @@ public class NMS_1_20_R4 extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		if (vanillaCommandDispatcher != null) {
+			return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		} else {
+			return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
+		}
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
@@ -70,6 +70,7 @@ import org.bukkit.scoreboard.Team;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -93,10 +94,16 @@ import static dev.jorel.commandapi.preprocessor.Unimplemented.REASON.*;
  */
 public abstract class NMS_Common extends CommandAPIBukkit<CommandSourceStack> {
 
-	private static final SafeVarHandle<MinecraftServer, CommandDispatcher> commandDispatcher;
+	private static final Field commandDispatcher;
 
 	static {
-		commandDispatcher = SafeVarHandle.ofOrNull(MinecraftServer.class, "vanillaCommandDispatcher", "vanillaCommandDispatcher", CommandDispatcher.class);
+		Field temporary;
+		try {
+			temporary = MinecraftServer.class.getDeclaredField("vanillaCommandDispatcher");
+		} catch (Exception e) {
+			temporary = null;
+		}
+		commandDispatcher = temporary;
 	}
 
 	private static NamespacedKey fromResourceLocation(ResourceLocation key) {


### PR DESCRIPTION
Some of this is not pretty but doing this the VarHandle-less way also got rid of the exception in the console which I didn't seem to do with VarHandles.

Nevertheless, this should make it possible to at least register commands using Paper 1.20.6 build 65 and onwards.

I plan to handle all this properly in #517 