### PR TITLE
Change vanillaCommandDispatcher to getCommands()

### DIFF
--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -551,7 +551,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes) {
 		if(!CommandAPI.canRegister()) {
 			// Usually, when registering commands during server startup, we can just put our commands into the
-			// `net.minecraft.server.MinecraftServer#vanillaCommandDispatcher` and leave it. As the server finishes setup,
+			// `net.minecraft.server.MinecraftServer#getCommands()` and leave it. As the server finishes setup,
 			// it and the CommandAPI do some extra stuff to make everything work, and we move on.
 			// So, if we want to register commands while the server is running, we need to do all that extra stuff, and
 			// that is what this code does.

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
@@ -714,7 +714,7 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
@@ -763,7 +763,7 @@ public class NMS_1_18_R2 extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
@@ -708,7 +708,7 @@ public class NMS_1_18_R1 extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
@@ -806,7 +806,7 @@ public abstract class NMS_1_19_Common extends NMS_CommonWithFunctions {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
@@ -696,7 +696,7 @@ public class NMS_1_19_3_R2 extends NMS_CommonWithFunctions {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
@@ -689,7 +689,7 @@ public class NMS_1_19_4_R3 extends NMS_CommonWithFunctions {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R2.java
@@ -710,7 +710,7 @@ public class NMS_1_20_R2 extends NMS_CommonWithFunctions {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R3.java
@@ -843,7 +843,7 @@ public class NMS_1_20_R3 extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
@@ -895,7 +895,7 @@ public class NMS_1_20_R4 extends NMS_Common {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
@@ -689,7 +689,7 @@ public class NMS_1_20_R1 extends NMS_CommonWithFunctions {
 
 	@Override
 	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
+		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().getCommands(), node);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
@@ -350,7 +350,11 @@ public abstract class NMS_Common extends CommandAPIBukkit<CommandSourceStack> {
 
 	@Override
 	public final CommandDispatcher<CommandSourceStack> getBrigadierDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher();
+		try {
+			return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+		} catch (Throwable e) {
+			return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher();
+		}
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -529,7 +529,7 @@ public class MockNMS extends Enums {
 		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
 		net.minecraft.server.v1_16_R3.CommandDispatcher commands = new net.minecraft.server.v1_16_R3.CommandDispatcher();
 		MockPlatform.setField(commands.getClass(), "b", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		
 
 		return (T) minecraftServerMock;
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -507,7 +507,7 @@ public class MockNMS extends Enums {
 			return new ServerFunctionManager(minecraftServerMock, serverFunctionLibrary) {
 				
 				// Make sure we don't use ServerFunctionManager#getDispatcher!
-				// That method accesses MinecraftServer.vanillaCommandDispatcher
+				// That method accesses MinecraftServer.getCommands()
 				// directly (boo) and that causes all sorts of nonsense.
 				@Override
 				public CommandDispatcher<CommandSourceStack> getDispatcher() {
@@ -522,7 +522,7 @@ public class MockNMS extends Enums {
 		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
 		Commands commands = new Commands();
 		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		
 
 		return (T) minecraftServerMock;
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -522,7 +522,7 @@ public class MockNMS extends Enums {
 			return new ServerFunctionManager(minecraftServerMock, serverFunctionLibrary) {
 				
 				// Make sure we don't use ServerFunctionManager#getDispatcher!
-				// That method accesses MinecraftServer.vanillaCommandDispatcher
+				// That method accesses MinecraftServer.getCommands()
 				// directly (boo) and that causes all sorts of nonsense.
 				@Override
 				public CommandDispatcher<CommandSourceStack> getDispatcher() {
@@ -537,7 +537,7 @@ public class MockNMS extends Enums {
 		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
 		Commands commands = new Commands();
 		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		
 
 		return (T) minecraftServerMock;
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -515,7 +515,7 @@ public class MockNMS extends Enums {
 			return new ServerFunctionManager(minecraftServerMock, serverFunctionLibrary) {
 				
 				// Make sure we don't use ServerFunctionManager#getDispatcher!
-				// That method accesses MinecraftServer.vanillaCommandDispatcher
+				// That method accesses MinecraftServer.getCommands()
 				// directly (boo) and that causes all sorts of nonsense.
 				@Override
 				public CommandDispatcher<CommandSourceStack> getDispatcher() {
@@ -530,7 +530,7 @@ public class MockNMS extends Enums {
 		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
 		Commands commands = new Commands();
 		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		
 
 		return (T) minecraftServerMock;
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -525,7 +525,7 @@ public class MockNMS extends Enums {
 			return new ServerFunctionManager(minecraftServerMock, serverFunctionLibrary) {
 				
 				// Make sure we don't use ServerFunctionManager#getDispatcher!
-				// That method accesses MinecraftServer.vanillaCommandDispatcher
+				// That method accesses MinecraftServer.getCommands()
 				// directly (boo) and that causes all sorts of nonsense.
 				@Override
 				public CommandDispatcher<CommandSourceStack> getDispatcher() {
@@ -540,7 +540,7 @@ public class MockNMS extends Enums {
 		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
 		Commands commands = new Commands();
 		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		
 
 		return (T) minecraftServerMock;
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.2/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.2/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -546,7 +546,7 @@ public class MockNMS extends Enums {
 			return new ServerFunctionManager(minecraftServerMock, serverFunctionLibrary) {
 				
 				// Make sure we don't use ServerFunctionManager#getDispatcher!
-				// That method accesses MinecraftServer.vanillaCommandDispatcher
+				// That method accesses MinecraftServer.getCommands()
 				// directly (boo) and that causes all sorts of nonsense.
 				@Override
 				public CommandDispatcher<CommandSourceStack> getDispatcher() {
@@ -561,7 +561,7 @@ public class MockNMS extends Enums {
 		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
 		Commands commands = new Commands();
 		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		
 
 		return (T) minecraftServerMock;
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.3/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.3/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -559,7 +559,7 @@ public class MockNMS extends Enums {
 			return new ServerFunctionManager(minecraftServerMock, serverFunctionLibrary) {
 				
 				// Make sure we don't use ServerFunctionManager#getDispatcher!
-				// That method accesses MinecraftServer.vanillaCommandDispatcher
+				// That method accesses MinecraftServer.getCommands()
 				// directly (boo) and that causes all sorts of nonsense.
 				@Override
 				public CommandDispatcher<CommandSourceStack> getDispatcher() {
@@ -574,7 +574,7 @@ public class MockNMS extends Enums {
 		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
 		Commands commands = new Commands();
 		MockPlatform.setField(commands.getClass(), "h", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		
 
 		return (T) minecraftServerMock;
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -693,7 +693,7 @@ public class MockNMS extends Enums {
 			return new ServerFunctionManager(minecraftServerMock, serverFunctionLibrary) {
 				
 				// Make sure we don't use ServerFunctionManager#getDispatcher!
-				// That method accesses MinecraftServer.vanillaCommandDispatcher
+				// That method accesses MinecraftServer.getCommands()
 				// directly (boo) and that causes all sorts of nonsense.
 				@Override
 				public CommandDispatcher<CommandSourceStack> getDispatcher() {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -523,7 +523,7 @@ public class MockNMS extends Enums {
 			return new ServerFunctionManager(minecraftServerMock, serverFunctionLibrary) {
 				
 				// Make sure we don't use ServerFunctionManager#getDispatcher!
-				// That method accesses MinecraftServer.vanillaCommandDispatcher
+				// That method accesses MinecraftServer.getCommands()
 				// directly (boo) and that causes all sorts of nonsense.
 				@Override
 				public CommandDispatcher<CommandSourceStack> getDispatcher() {
@@ -538,7 +538,7 @@ public class MockNMS extends Enums {
 		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
 		Commands commands = new Commands();
 		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		
 
 		return (T) minecraftServerMock;
 	}

--- a/commandapi-platforms/pom.xml
+++ b/commandapi-platforms/pom.xml
@@ -13,10 +13,6 @@
 	<artifactId>commandapi-platforms</artifactId>
 	<packaging>pom</packaging>
 
-	<modules>
-		<module>commandapi-bukkit</module>
-	</modules>
-
 	<profiles>
 		<!-- Choose which platforms get built -->
 		<profile>

--- a/commandapi-platforms/pom.xml
+++ b/commandapi-platforms/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>commandapi-platforms</artifactId>
 	<packaging>pom</packaging>
 
+	<modules>
+		<module>commandapi-bukkit</module>
+	</modules>
+
 	<profiles>
 		<!-- Choose which platforms get built -->
 		<profile>


### PR DESCRIPTION
In current paper build, vanillaCommandDispatcher was removed. so it requires to use getCommands().