### PR TITLE
Delegate Bukkit command registering logic to `CommandRegistrationStrategy`

### DIFF
--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -176,6 +176,10 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		commandRegistrationStrategy = createCommandRegistrationStrategy();
 	}
 
+	protected CommandRegistrationStrategy<Source> getCommandRegistrationStrategy() {
+		return commandRegistrationStrategy;
+	}
+
 	@Override
 	public void onEnable() {
 		JavaPlugin plugin = config.getPlugin();

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -444,12 +444,12 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes) {
 		commandRegistrationStrategy.postCommandRegistration(registeredCommand, resultantNode, aliasNodes);
 
-		if(!CommandAPI.canRegister()) {
+		if (!CommandAPI.canRegister()) {
 			// Adding the command to the help map usually happens in `CommandAPIBukkit#onEnable`
 			updateHelpForCommands(List.of(registeredCommand));
 
 			// Sending command dispatcher packets usually happens when Players join the server
-			for(Player p: Bukkit.getOnlinePlayers()) {
+			for (Player p : Bukkit.getOnlinePlayers()) {
 				p.updateCommands();
 			}
 		}
@@ -471,9 +471,9 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 	 *
 	 * @param commandName          the name of the command to unregister
 	 * @param unregisterNamespaces whether the unregistration system should attempt to remove versions of the
-	 *                                command that start with a namespace. E.g. `minecraft:command`, `bukkit:command`,
-	 *                                or `plugin:command`. If true, these namespaced versions of a command are also
-	 *                                unregistered.
+	 *                             command that start with a namespace. E.g. `minecraft:command`, `bukkit:command`,
+	 *                             or `plugin:command`. If true, these namespaced versions of a command are also
+	 *                             unregistered.
 	 * @param unregisterBukkit     whether the unregistration system should unregister Vanilla or Bukkit commands. If true,
 	 *                             only Bukkit commands are unregistered, otherwise only Vanilla commands are unregistered.
 	 *                             For the purposes of this parameter, commands registered using the CommandAPI are Vanilla
@@ -488,7 +488,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 		commandRegistrationStrategy.unregister(commandName, unregisterNamespaces, unregisterBukkit);
 
-		if(!CommandAPI.canRegister()) {
+		if (!CommandAPI.canRegister()) {
 			// Help topics (from Bukkit and CommandAPI) are only setup after plugins enable, so we only need to worry
 			//  about removing them once the server is loaded.
 			getHelpMap().remove("/" + commandName);
@@ -631,5 +631,4 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		}
 		return false;
 	}
-
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -105,6 +105,10 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		}
 	}
 
+	public CommandRegistrationStrategy<Source> getCommandRegistrationStrategy() {
+		return commandRegistrationStrategy;
+	}
+
 	@Override
 	public void onLoad(CommandAPIConfig<?> config) {
 		if(config instanceof CommandAPIBukkitConfig bukkitConfig) {
@@ -174,10 +178,6 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		paper = new PaperImplementations(isPaperPresent, isFoliaPresent, this);
 
 		commandRegistrationStrategy = createCommandRegistrationStrategy();
-	}
-
-	protected CommandRegistrationStrategy<Source> getCommandRegistrationStrategy() {
-		return commandRegistrationStrategy;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -18,7 +17,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -26,14 +24,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Keyed;
 import org.bukkit.command.BlockCommandSender;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandMap;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.command.ProxiedCommandSender;
 import org.bukkit.command.RemoteConsoleCommandSender;
-import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -49,9 +44,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
-import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-import com.mojang.brigadier.tree.RootCommandNode;
 
 import dev.jorel.commandapi.arguments.AbstractArgument;
 import dev.jorel.commandapi.arguments.Argument;
@@ -71,7 +64,6 @@ import dev.jorel.commandapi.commandsenders.BukkitProxiedCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitRemoteConsoleCommandSender;
 import dev.jorel.commandapi.exceptions.WrapperCommandSyntaxException;
 import dev.jorel.commandapi.nms.NMS;
-import dev.jorel.commandapi.preprocessor.RequireField;
 import dev.jorel.commandapi.preprocessor.Unimplemented;
 import dev.jorel.commandapi.wrappers.NativeProxyCommandSender;
 import net.kyori.adventure.text.Component;
@@ -80,36 +72,13 @@ import net.md_5.bungee.api.chat.BaseComponent;
 // CommandAPIBukkit is an CommandAPIPlatform, but also needs all of the methods from
 // NMS, so it implements NMS. Our implementation of CommandAPIBukkit is now derived
 // using the version handler (and thus, deferred to our NMS-specific implementations)
-
-@RequireField(in = CommandNode.class, name = "children", ofType = Map.class)
-@RequireField(in = CommandNode.class, name = "literals", ofType = Map.class)
-@RequireField(in = CommandNode.class, name = "arguments", ofType = Map.class)
 public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Argument<?>, CommandSender, Source>, NMS<Source> {
 
 	// References to utility classes
 	private static CommandAPIBukkit<?> instance;
 	private static InternalBukkitConfig config;
 	private PaperImplementations paper;
-
-	// Namespaces
-	private final Set<String> namespacesToFix = new HashSet<>();
-	private RootCommandNode<Source> minecraftCommandNamespaces = new RootCommandNode<>();
-
-	// Static VarHandles
-	// I'd like to make the Maps here `Map<String, CommandNode<Source>>`, but these static fields cannot use the type
-	//  parameter Source. We still need to cast to that signature for map, so Map is raw.
-	private static final SafeVarHandle<CommandNode<?>, Map> commandNodeChildren;
-	private static final SafeVarHandle<CommandNode<?>, Map> commandNodeLiterals;
-	private static final SafeVarHandle<CommandNode<?>, Map> commandNodeArguments;
-	private static final SafeVarHandle<SimpleCommandMap, Map<String, Command>> commandMapKnownCommands;
-
-	// Compute all var handles all in one go so we don't do this during main server runtime
-	static {
-		commandNodeChildren = SafeVarHandle.ofOrNull(CommandNode.class, "children", "children", Map.class);
-		commandNodeLiterals = SafeVarHandle.ofOrNull(CommandNode.class, "literals", "literals", Map.class);
-		commandNodeArguments = SafeVarHandle.ofOrNull(CommandNode.class, "arguments", "arguments", Map.class);
-		commandMapKnownCommands = SafeVarHandle.ofOrNull(SimpleCommandMap.class, "knownCommands", "knownCommands", Map.class);
-	}
+	private CommandRegistrationStrategy<Source> commandRegistrationStrategy;
 
 	protected CommandAPIBukkit() {
 		CommandAPIBukkit.instance = this;
@@ -203,6 +172,8 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		}
 
 		paper = new PaperImplementations(isPaperPresent, isFoliaPresent, this);
+
+		commandRegistrationStrategy = createCommandRegistrationStrategy();
 	}
 
 	@Override
@@ -210,10 +181,8 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		JavaPlugin plugin = config.getPlugin();
 
 		new Schedulers(paper).scheduleSyncDelayed(plugin, () -> {
-			// Fix namespaces first thing when starting the server
-			fixNamespaces();
-			// Sort out permissions after the server has finished registering them all
-			fixPermissions();
+			commandRegistrationStrategy.runTasksAfterServerStart();
+
 			if (paper.isFoliaPresent()) {
 				CommandAPI.logNormal("Skipping initial datapack reloading because Folia was detected");
 			} else {
@@ -235,55 +204,6 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		}, getConfiguration().getPlugin());
 
 		paper.registerReloadHandler(plugin);
-	}
-
-	/*
-	 * Makes permission checks more "Bukkit" like and less "Vanilla Minecraft" like
-	 */
-	private void fixPermissions() {
-		// Get the command map to find registered commands
-		CommandMap map = paper.getCommandMap();
-		final Map<String, CommandPermission> permissionsToFix = CommandAPIHandler.getInstance().registeredPermissions;
-
-		if (!permissionsToFix.isEmpty()) {
-			CommandAPI.logInfo("Linking permissions to commands:");
-
-			for (Map.Entry<String, CommandPermission> entry : permissionsToFix.entrySet()) {
-				String cmdName = entry.getKey();
-				CommandPermission perm = entry.getValue();
-				CommandAPI.logInfo("  " + perm.toString() + " -> /" + cmdName);
-
-				final String permNode = unpackInternalPermissionNodeString(perm);
-
-				/*
-				 * Sets the permission. If you have to be OP to run this command, we set the
-				 * permission to null. Doing so means that Bukkit's "testPermission" will always
-				 * return true, however since the command's permission check occurs internally
-				 * via the CommandAPI, this isn't a problem.
-				 *
-				 * If anyone dares tries to use testPermission() on this command, seriously,
-				 * what are you doing and why?
-				 */
-				Command command = map.getCommand(cmdName);
-				if(command != null && isVanillaCommandWrapper(command)) {
-					command.setPermission(permNode);
-				}
-			}
-		}
-		CommandAPI.logNormal("Linked " + permissionsToFix.size() + " Bukkit permissions to commands");
-	}
-	
-	private String unpackInternalPermissionNodeString(CommandPermission perm) {
-		final Optional<String> optionalPerm = perm.getPermission();
-		if (perm.isNegated() || perm.equals(CommandPermission.NONE) || perm.equals(CommandPermission.OP)) {
-			return "";
-		} else if (optionalPerm.isPresent()) {
-			return optionalPerm.get();
-		} else {
-			throw new IllegalStateException("Invalid permission detected: " + perm +
-				"! This should never happen - if you're seeing this message, please" +
-				"contact the developers of the CommandAPI, we'd love to know how you managed to get this error!");
-		}
 	}
 
 	/*
@@ -438,33 +358,6 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		}
 	}
 
-	private void fixNamespaces() {
-		Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) paper.getCommandMap());
-		CommandDispatcher<Source> resourcesDispatcher = getResourcesDispatcher();
-		// Remove namespaces
-		for (String command : namespacesToFix) {
-			knownCommands.remove(command);
-			removeBrigadierCommands(resourcesDispatcher, command, false, c -> true);
-		}
-
-		// Add back certain minecraft: namespace commands
-		RootCommandNode<Source> resourcesRootNode = resourcesDispatcher.getRoot();
-		RootCommandNode<Source> brigadierRootNode = getBrigadierDispatcher().getRoot();
-		for (CommandNode<Source> node : minecraftCommandNamespaces.getChildren()) {
-			knownCommands.put(node.getName(), wrapToVanillaCommandWrapper(node));
-			resourcesRootNode.addChild(node);
-
-			// VanillaCommandWrappers in the CommandMap defer to the Brigadier dispatcher when executing.
-			// While the minecraft namespace usually does not exist in the Brigadier dispatcher, in the case of a
-			//  command conflict we do need this node to exist separately from the unnamespaced version to keep the
-			//  commands separate.
-			brigadierRootNode.addChild(node);
-		}
-		// Clear minecraftCommandNamespaces for dealing with command conflicts after the server is enabled
-		//  See `CommandAPIBukkit#postCommandRegistration`
-		minecraftCommandNamespaces = new RootCommandNode<>();
-	}
-
 	@Override
 	public void onDisable() {
 		// Nothing to do
@@ -549,46 +442,9 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 	@Override
 	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes) {
+		commandRegistrationStrategy.postCommandRegistration(registeredCommand, resultantNode, aliasNodes);
+
 		if(!CommandAPI.canRegister()) {
-			// Usually, when registering commands during server startup, we can just put our commands into the
-			// `net.minecraft.server.MinecraftServer#vanillaCommandDispatcher` and leave it. As the server finishes setup,
-			// it and the CommandAPI do some extra stuff to make everything work, and we move on.
-			// So, if we want to register commands while the server is running, we need to do all that extra stuff, and
-			// that is what this code does.
-			// We could probably call all those methods to sync everything up, but in the spirit of avoiding side effects
-			// and avoiding doing things twice for existing commands, this is a distilled version of those methods.
-
-			Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) paper.getCommandMap());
-			RootCommandNode<Source> root = getResourcesDispatcher().getRoot();
-
-			String name = resultantNode.getLiteral();
-			String namespace = registeredCommand.namespace();
-			String permNode = unpackInternalPermissionNodeString(registeredCommand.permission());
-
-			registerCommand(knownCommands, root, name, permNode, namespace, resultantNode);
-
-			// Do the same for the aliases
-			for(LiteralCommandNode<Source> node: aliasNodes) {
-				registerCommand(knownCommands, root, node.getLiteral(), permNode, namespace, node);
-			}
-
-			Collection<CommandNode<Source>> minecraftNamespacesToFix = minecraftCommandNamespaces.getChildren();
-			if (!minecraftNamespacesToFix.isEmpty()) {
-				// Adding new `minecraft` namespace nodes to the Brigadier dispatcher
-				//  usually happens in `CommandAPIBukkit#fixNamespaces`.
-				// Note that the previous calls to `CommandAPIBukkit#registerCommand` in this method
-				//  will have already dealt with adding the nodes here to the resources dispatcher.
-				// We also have to set the permission to simulate the result of `CommandAPIBukkit#fixPermissions`.
-				RootCommandNode<Source> brigadierRootNode = getBrigadierDispatcher().getRoot();
-				for (CommandNode<Source> node : minecraftNamespacesToFix) {
-					Command minecraftNamespaceCommand = wrapToVanillaCommandWrapper(node);
-					knownCommands.put(node.getName(), minecraftNamespaceCommand);
-					minecraftNamespaceCommand.setPermission(permNode);
-					brigadierRootNode.addChild(node);
-				}
-				minecraftCommandNamespaces = new RootCommandNode<>();
-			}
-
 			// Adding the command to the help map usually happens in `CommandAPIBukkit#onEnable`
 			updateHelpForCommands(List.of(registeredCommand));
 
@@ -599,86 +455,9 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		}
 	}
 
-	private void registerCommand(Map<String, Command> knownCommands, RootCommandNode<Source> root, String name, String permNode, String namespace, LiteralCommandNode<Source> resultantNode) {
-		// Wrapping Brigadier nodes into VanillaCommandWrappers and putting them in the CommandMap usually happens
-		// in `CraftServer#setVanillaCommands`
-		Command command = wrapToVanillaCommandWrapper(resultantNode);
-		knownCommands.putIfAbsent(name, command);
-
-		// Adding permissions to these Commands usually happens in `CommandAPIBukkit#fixPermissions`
-		command.setPermission(permNode);
-
-		// Adding commands to the other (Why bukkit/spigot?!) dispatcher usually happens in `CraftServer#syncCommands`
-		root.addChild(resultantNode);
-
-		// Handle namespace
-		LiteralCommandNode<Source> namespacedNode = CommandAPIHandler.getInstance().namespaceNode(resultantNode, namespace);
-		if (namespace.equals("minecraft")) {
-			// The minecraft namespace version should be registered as a straight alias of the original command, since
-			//  the `minecraft:name` node does not exist in the Brigadier dispatcher, which is referenced by
-			//  VanillaCommandWrapper (note this is not true if there is a command conflict, but
-			//  `CommandAPIBukkit#postCommandRegistration` will deal with this later using `minecraftCommandNamespaces`).
-			knownCommands.putIfAbsent("minecraft:" + name, command);
-		} else {
-			// A custom namespace should be registered like a separate command, so that it can reference the namespaced
-			//  node, rather than the original unnamespaced node
-			Command namespacedCommand = wrapToVanillaCommandWrapper(namespacedNode);
-			knownCommands.putIfAbsent(namespacedCommand.getName(), namespacedCommand);
-			namespacedCommand.setPermission(permNode);
-		}
-		// In both cases, add the node to the resources dispatcher
-		root.addChild(namespacedNode);
-	}
-
 	@Override
 	public LiteralCommandNode<Source> registerCommandNode(LiteralArgumentBuilder<Source> node, String namespace) {
-		RootCommandNode<Source> rootNode = getBrigadierDispatcher().getRoot();
-
-		LiteralCommandNode<Source> builtNode = node.build();
-		String name = node.getLiteral();
-		if (namespace.equals("minecraft")) {
-			if (namespacesToFix.contains("minecraft:" + name)) {
-				// This command wants to exist as `minecraft:name`
-				// However, another command has requested that `minecraft:name` be removed
-				// We'll keep track of everything that should be `minecraft:name` in
-				//  `minecraftCommandNamespaces` and fix this later in `#fixNamespaces`
-				minecraftCommandNamespaces.addChild(CommandAPIHandler.getInstance().namespaceNode(builtNode, "minecraft"));
-			}
-		} else {
-			// Make sure to remove the `minecraft:name` and
-			//  `minecraft:namespace:name` commands Bukkit will create
-			fillNamespacesToFix(name, namespace + ":" + name);
-
-			// Create the namespaced node
-			rootNode.addChild(CommandAPIHandler.getInstance().namespaceNode(builtNode, namespace));
-		}
-
-		// Add the main node to dispatcher
-		//  We needed to wait until after `fillNamespacesToFix` was called to do this, in case a previous 
-		//  `minecraft:name` version of the command needed to be saved separately before this node was added
-		rootNode.addChild(builtNode);
-		
-		return builtNode;
-	}
-
-	private void fillNamespacesToFix(String... namespacedCommands) {
-		for (String namespacedCommand : namespacedCommands) {
-			// We'll remove these commands later when fixNamespaces is called
-			if (!namespacesToFix.add("minecraft:" + namespacedCommand)) {
-				continue;
-			}
-
-			// If this is the first time considering this command for removal
-			// and there is already a command with this name in the dispatcher
-			// then, the command currently in the dispatcher is supposed to appear as `minecraft:command`
-			CommandNode<Source> currentNode = getBrigadierDispatcher().getRoot().getChild(namespacedCommand);
-			if(currentNode != null) {
-				// We'll keep track of everything that should be `minecraft:command` in
-				//  `minecraftCommandNamespaces` and fix this later in `#fixNamespaces`
-				// TODO: Ideally, we should be working without this cast to LiteralCommandNode. I don't know if this can fail
-				minecraftCommandNamespaces.addChild(CommandAPIHandler.getInstance().namespaceNode((LiteralCommandNode<Source>) currentNode, "minecraft"));
-			}
-		}
+		return commandRegistrationStrategy.registerCommandNode(node, namespace);
 	}
 
 	@Override
@@ -707,41 +486,9 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 	private void unregisterInternal(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit) {
 		CommandAPI.logInfo("Unregistering command /" + commandName);
 
-		if(!unregisterBukkit) {
-			// Remove nodes from the Vanilla dispatcher
-			// This dispatcher doesn't usually have namespaced version of commands (those are created when commands
-			//  are transferred to Bukkit's CommandMap), but if they ask, we'll do it
-			removeBrigadierCommands(getBrigadierDispatcher(), commandName, unregisterNamespaces, c -> true);
-
-			// Update the dispatcher file
-			CommandAPIHandler.getInstance().writeDispatcherToFile();
-		}
-
-		if(unregisterBukkit || !CommandAPI.canRegister()) {
-			// We need to remove commands from Bukkit's CommandMap if we're unregistering a Bukkit command, or
-			//  if we're unregistering after the server is enabled, because `CraftServer#setVanillaCommands` will have
-			//  moved the Vanilla command into the CommandMap
-			Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) paper.getCommandMap());
-
-			// If we are unregistering a Bukkit command, DO NOT unregister VanillaCommandWrappers
-			// If we are unregistering a Vanilla command, ONLY unregister VanillaCommandWrappers
-			boolean isMainVanilla = isVanillaCommandWrapper(knownCommands.get(commandName));
-			if(unregisterBukkit ^ isMainVanilla) knownCommands.remove(commandName);
-
-			if(unregisterNamespaces) {
-				removeCommandNamespace(knownCommands, commandName, c -> unregisterBukkit ^ isVanillaCommandWrapper(c));
-			}
-		}
+		commandRegistrationStrategy.unregister(commandName, unregisterNamespaces, unregisterBukkit);
 
 		if(!CommandAPI.canRegister()) {
-			// If the server is enabled, we have extra cleanup to do
-
-			// Remove commands from the resources dispatcher
-			// If we are unregistering a Bukkit command, ONLY unregister BukkitCommandWrappers
-			// If we are unregistering a Vanilla command, DO NOT unregister BukkitCommandWrappers
-			removeBrigadierCommands(getResourcesDispatcher(), commandName, unregisterNamespaces,
-				c -> !unregisterBukkit ^ isBukkitCommandWrapper(c));
-
 			// Help topics (from Bukkit and CommandAPI) are only setup after plugins enable, so we only need to worry
 			//  about removing them once the server is loaded.
 			getHelpMap().remove("/" + commandName);
@@ -753,50 +500,10 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 		}
 	}
 
-	private void removeBrigadierCommands(CommandDispatcher<Source> dispatcher, String commandName,
-										 boolean unregisterNamespaces, Predicate<CommandNode<Source>> extraCheck) {
-		RootCommandNode<?> root = dispatcher.getRoot();
-		Map<String, CommandNode<Source>> children = (Map<String, CommandNode<Source>>) commandNodeChildren.get(root);
-		Map<String, CommandNode<Source>> literals = (Map<String, CommandNode<Source>>) commandNodeLiterals.get(root);
-		Map<String, CommandNode<Source>> arguments = (Map<String, CommandNode<Source>>) commandNodeArguments.get(root);
-
-		removeCommandFromMapIfCheckPasses(children, commandName, extraCheck);
-		removeCommandFromMapIfCheckPasses(literals, commandName, extraCheck);
-		// Commands should really only be represented as literals, but it is technically possible
-		// to put an ArgumentCommandNode in the root, so we'll check
-		removeCommandFromMapIfCheckPasses(arguments, commandName, extraCheck);
-
-		if (unregisterNamespaces) {
-			removeCommandNamespace(children, commandName, extraCheck);
-			removeCommandNamespace(literals, commandName, extraCheck);
-			removeCommandNamespace(arguments, commandName, extraCheck);
-		}
-	}
-
-	private static <T> void removeCommandNamespace(Map<String, T> map, String commandName, Predicate<T> extraCheck) {
-		for (String key : new HashSet<>(map.keySet())) {
-			if (!isThisTheCommandButNamespaced(commandName, key)) continue;
-
-			removeCommandFromMapIfCheckPasses(map, key, extraCheck);
-		}
-	}
-
-	private static <T> void removeCommandFromMapIfCheckPasses(Map<String, T> map, String key, Predicate<T> extraCheck) {
-		T element = map.get(key);
-		if (element == null) return;
-		if (extraCheck.test(map.get(key))) map.remove(key);
-	}
-
-	private static boolean isThisTheCommandButNamespaced(String commandName, String key) {
-		if(!key.contains(":")) return false;
-		String[] split = key.split(":");
-		if(split.length < 2) return false;
-		return split[1].equalsIgnoreCase(commandName);
-	}
-
 	@Override
-	@Unimplemented(because = REQUIRES_MINECRAFT_SERVER)
-	public abstract CommandDispatcher<Source> getBrigadierDispatcher();
+	public final CommandDispatcher<Source> getBrigadierDispatcher() {
+		return commandRegistrationStrategy.getBrigadierDispatcher();
+	}
 
 	@Override
 	@Unimplemented(because = {REQUIRES_MINECRAFT_SERVER, VERSION_SPECIFIC_IMPLEMENTATION})

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandRegistrationStrategy.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandRegistrationStrategy.java
@@ -31,9 +31,8 @@ public abstract class CommandRegistrationStrategy<Source> {
 	}
 
 	// Utility methods
-	protected void removeBrigadierCommands(CommandDispatcher<Source> dispatcher, String commandName,
+	protected void removeBrigadierCommands(RootCommandNode<Source> root, String commandName,
 										   boolean unregisterNamespaces, Predicate<CommandNode<Source>> extraCheck) {
-		RootCommandNode<?> root = dispatcher.getRoot();
 		Map<String, CommandNode<Source>> children = (Map<String, CommandNode<Source>>) commandNodeChildren.get(root);
 		Map<String, CommandNode<Source>> literals = (Map<String, CommandNode<Source>>) commandNodeLiterals.get(root);
 		Map<String, CommandNode<Source>> arguments = (Map<String, CommandNode<Source>>) commandNodeArguments.get(root);

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandRegistrationStrategy.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandRegistrationStrategy.java
@@ -32,7 +32,7 @@ public abstract class CommandRegistrationStrategy<Source> {
 
 	// Utility methods
 	protected void removeBrigadierCommands(CommandDispatcher<Source> dispatcher, String commandName,
-										boolean unregisterNamespaces, Predicate<CommandNode<Source>> extraCheck) {
+										   boolean unregisterNamespaces, Predicate<CommandNode<Source>> extraCheck) {
 		RootCommandNode<?> root = dispatcher.getRoot();
 		Map<String, CommandNode<Source>> children = (Map<String, CommandNode<Source>>) commandNodeChildren.get(root);
 		Map<String, CommandNode<Source>> literals = (Map<String, CommandNode<Source>>) commandNodeLiterals.get(root);
@@ -66,9 +66,9 @@ public abstract class CommandRegistrationStrategy<Source> {
 	}
 
 	protected static boolean isThisTheCommandButNamespaced(String commandName, String key) {
-		if(!key.contains(":")) return false;
+		if (!key.contains(":")) return false;
 		String[] split = key.split(":");
-		if(split.length < 2) return false;
+		if (split.length < 2) return false;
 		return split[1].equalsIgnoreCase(commandName);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandRegistrationStrategy.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandRegistrationStrategy.java
@@ -82,4 +82,6 @@ public abstract class CommandRegistrationStrategy<Source> {
 	public abstract LiteralCommandNode<Source> registerCommandNode(LiteralArgumentBuilder<Source> node, String namespace);
 
 	public abstract void unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit);
+
+	public abstract void preReloadDataPacks();
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandRegistrationStrategy.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandRegistrationStrategy.java
@@ -1,0 +1,85 @@
+package dev.jorel.commandapi;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
+import dev.jorel.commandapi.preprocessor.RequireField;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+@RequireField(in = CommandNode.class, name = "children", ofType = Map.class)
+@RequireField(in = CommandNode.class, name = "literals", ofType = Map.class)
+@RequireField(in = CommandNode.class, name = "arguments", ofType = Map.class)
+public abstract class CommandRegistrationStrategy<Source> {
+	// Reflection
+	// I'd like to make the Maps here `Map<String, CommandNode<Source>>`, but these static fields cannot use the type
+	//  parameter Source. We still need to cast to that signature for map, so Map is raw.
+	static final SafeVarHandle<CommandNode<?>, Map> commandNodeChildren;
+	private static final SafeVarHandle<CommandNode<?>, Map> commandNodeLiterals;
+	private static final SafeVarHandle<CommandNode<?>, Map> commandNodeArguments;
+
+	// Compute all var handles all in one go so we don't do this during main server runtime
+	static {
+		commandNodeChildren = SafeVarHandle.ofOrNull(CommandNode.class, "children", "children", Map.class);
+		commandNodeLiterals = SafeVarHandle.ofOrNull(CommandNode.class, "literals", "literals", Map.class);
+		commandNodeArguments = SafeVarHandle.ofOrNull(CommandNode.class, "arguments", "arguments", Map.class);
+	}
+
+	// Utility methods
+	protected void removeBrigadierCommands(CommandDispatcher<Source> dispatcher, String commandName,
+										boolean unregisterNamespaces, Predicate<CommandNode<Source>> extraCheck) {
+		RootCommandNode<?> root = dispatcher.getRoot();
+		Map<String, CommandNode<Source>> children = (Map<String, CommandNode<Source>>) commandNodeChildren.get(root);
+		Map<String, CommandNode<Source>> literals = (Map<String, CommandNode<Source>>) commandNodeLiterals.get(root);
+		Map<String, CommandNode<Source>> arguments = (Map<String, CommandNode<Source>>) commandNodeArguments.get(root);
+
+		removeCommandFromMapIfCheckPasses(children, commandName, extraCheck);
+		removeCommandFromMapIfCheckPasses(literals, commandName, extraCheck);
+		// Commands should really only be represented as literals, but it is technically possible
+		// to put an ArgumentCommandNode in the root, so we'll check
+		removeCommandFromMapIfCheckPasses(arguments, commandName, extraCheck);
+
+		if (unregisterNamespaces) {
+			removeCommandNamespace(children, commandName, extraCheck);
+			removeCommandNamespace(literals, commandName, extraCheck);
+			removeCommandNamespace(arguments, commandName, extraCheck);
+		}
+	}
+
+	protected static <T> void removeCommandNamespace(Map<String, T> map, String commandName, Predicate<T> extraCheck) {
+		for (String key : new HashSet<>(map.keySet())) {
+			if (!isThisTheCommandButNamespaced(commandName, key)) continue;
+
+			removeCommandFromMapIfCheckPasses(map, key, extraCheck);
+		}
+	}
+
+	protected static <T> void removeCommandFromMapIfCheckPasses(Map<String, T> map, String key, Predicate<T> extraCheck) {
+		T element = map.get(key);
+		if (element == null) return;
+		if (extraCheck.test(element)) map.remove(key);
+	}
+
+	protected static boolean isThisTheCommandButNamespaced(String commandName, String key) {
+		if(!key.contains(":")) return false;
+		String[] split = key.split(":");
+		if(split.length < 2) return false;
+		return split[1].equalsIgnoreCase(commandName);
+	}
+
+	// Behavior methods
+	public abstract CommandDispatcher<Source> getBrigadierDispatcher();
+
+	public abstract void runTasksAfterServerStart();
+
+	public abstract void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes);
+
+	public abstract LiteralCommandNode<Source> registerCommandNode(LiteralArgumentBuilder<Source> node, String namespace);
+
+	public abstract void unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit);
+}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
@@ -1,0 +1,54 @@
+package dev.jorel.commandapi;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+
+import java.util.List;
+
+/**
+ * Handles logic for registering commands after Paper build 65, where https://github.com/PaperMC/Paper/pull/8235
+ * changed a bunch of the behind-the-scenes logic.
+ */
+public class PaperCommandRegistration<Source> extends CommandRegistrationStrategy<Source> {
+	// References to necessary objects
+	private final CommandDispatcher<Source> brigadierDispatcher;
+
+	public PaperCommandRegistration(CommandDispatcher<Source> brigadierDispatcher) {
+		this.brigadierDispatcher = brigadierDispatcher;
+	}
+
+	@Override
+	public CommandDispatcher<Source> getBrigadierDispatcher() {
+		return brigadierDispatcher;
+	}
+
+	@Override
+	public void runTasksAfterServerStart() {
+		// Nothing to do
+	}
+
+	@Override
+	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes) {
+		// Nothing to do
+	}
+
+	@Override
+	public LiteralCommandNode<Source> registerCommandNode(LiteralArgumentBuilder<Source> node, String namespace) {
+		LiteralCommandNode<Source> builtNode = brigadierDispatcher.register(node);
+
+		// Namespace is not empty on Bukkit forks
+		brigadierDispatcher.getRoot().addChild(CommandAPIHandler.getInstance().namespaceNode(builtNode, namespace));
+
+		return builtNode;
+	}
+
+	@Override
+	public void unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit) {
+		// Remove nodes from the  dispatcher
+		removeBrigadierCommands(brigadierDispatcher, commandName, unregisterNamespaces, c -> true);
+
+		// Update the dispatcher file
+		CommandAPIHandler.getInstance().writeDispatcherToFile();
+	}
+}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
@@ -22,9 +22,7 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 	// Store registered commands nodes for eventual reloads
 	private final RootCommandNode<Source> registeredNodes = new RootCommandNode<>();
 
-	public PaperCommandRegistration(
-		Supplier<CommandDispatcher<Source>> getBrigadierDispatcher, Predicate<CommandNode<Source>> isBukkitCommand
-	) {
+	public PaperCommandRegistration(Supplier<CommandDispatcher<Source>> getBrigadierDispatcher, Predicate<CommandNode<Source>> isBukkitCommand) {
 		this.getBrigadierDispatcher = getBrigadierDispatcher;
 		this.isBukkitCommand = isBukkitCommand;
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperImplementations.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperImplementations.java
@@ -58,6 +58,9 @@ public class PaperImplementations {
 
 				@EventHandler
 				public void onServerReloadResources(ServerResourcesReloadedEvent event) {
+					// This event is called after Paper is done with everything command related
+					// which means we can put commands back
+					CommandAPIBukkit.get().getCommandRegistrationStrategy().preReloadDataPacks();
 					CommandAPI.logNormal("/minecraft:reload detected. Reloading CommandAPI commands!");
 					nmsInstance.reloadDataPacks();
 				}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/SpigotCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/SpigotCommandRegistration.java
@@ -70,16 +70,15 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 
 	private void fixNamespaces() {
 		Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) commandAPIBukkit.getPaper().getCommandMap());
-		CommandDispatcher<Source> resourcesDispatcher = getResourcesDispatcher.get();
+		RootCommandNode<Source> resourcesRootNode = getResourcesDispatcher.get().getRoot();
 
 		// Remove namespaces
 		for (String command : namespacesToFix) {
 			knownCommands.remove(command);
-			removeBrigadierCommands(resourcesDispatcher, command, false, c -> true);
+			removeBrigadierCommands(resourcesRootNode, command, false, c -> true);
 		}
 
 		// Add back certain minecraft: namespace commands
-		RootCommandNode<Source> resourcesRootNode = resourcesDispatcher.getRoot();
 		RootCommandNode<Source> brigadierRootNode = brigadierDispatcher.getRoot();
 		for (CommandNode<Source> node : minecraftCommandNamespaces.getChildren()) {
 			knownCommands.put(node.getName(), commandAPIBukkit.wrapToVanillaCommandWrapper(node));
@@ -92,7 +91,7 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 			brigadierRootNode.addChild(node);
 		}
 		// Clear minecraftCommandNamespaces for dealing with command conflicts after the server is enabled
-		//  See `CommandAPIBukkit#postCommandRegistration`
+		//  See `SpigotCommandRegistration#postCommandRegistration`
 		minecraftCommandNamespaces = new RootCommandNode<>();
 	}
 
@@ -264,7 +263,7 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 			// Remove nodes from the Vanilla dispatcher
 			// This dispatcher doesn't usually have namespaced version of commands (those are created when commands
 			//  are transferred to Bukkit's CommandMap), but if they ask, we'll do it
-			removeBrigadierCommands(brigadierDispatcher, commandName, unregisterNamespaces, c -> true);
+			removeBrigadierCommands(brigadierDispatcher.getRoot(), commandName, unregisterNamespaces, c -> true);
 
 			// Update the dispatcher file
 			CommandAPIHandler.getInstance().writeDispatcherToFile();
@@ -292,7 +291,7 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 			// Remove commands from the resources dispatcher
 			// If we are unregistering a Bukkit command, ONLY unregister BukkitCommandWrappers
 			// If we are unregistering a Vanilla command, DO NOT unregister BukkitCommandWrappers
-			removeBrigadierCommands(getResourcesDispatcher.get(), commandName, unregisterNamespaces,
+			removeBrigadierCommands(getResourcesDispatcher.get().getRoot(), commandName, unregisterNamespaces,
 				c -> !unregisterBukkit ^ commandAPIBukkit.isBukkitCommandWrapper(c));
 		}
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/SpigotCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/SpigotCommandRegistration.java
@@ -124,7 +124,7 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 				 * what are you doing and why?
 				 */
 				Command command = map.getCommand(cmdName);
-				if(command != null && commandAPIBukkit.isVanillaCommandWrapper(command)) {
+				if (command != null && commandAPIBukkit.isVanillaCommandWrapper(command)) {
 					command.setPermission(permNode);
 				}
 			}
@@ -135,7 +135,7 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 	@Override
 	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes) {
 
-		if(!CommandAPI.canRegister()) {
+		if (!CommandAPI.canRegister()) {
 			// Usually, when registering commands during server startup, we can just put our commands into the
 			// `net.minecraft.server.MinecraftServer#vanillaCommandDispatcher` and leave it. As the server finishes setup,
 			// it and the CommandAPI do some extra stuff to make everything work, and we move on.
@@ -250,7 +250,7 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 			// and there is already a command with this name in the dispatcher
 			// then, the command currently in the dispatcher is supposed to appear as `minecraft:command`
 			CommandNode<Source> currentNode = brigadierDispatcher.getRoot().getChild(namespacedCommand);
-			if(currentNode != null) {
+			if (currentNode != null) {
 				// We'll keep track of everything that should be `minecraft:command` in
 				//  `minecraftCommandNamespaces` and fix this later in `#fixNamespaces`
 				// TODO: Ideally, we should be working without this cast to LiteralCommandNode. I don't know if this can fail
@@ -261,7 +261,7 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 
 	@Override
 	public void unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit) {
-		if(!unregisterBukkit) {
+		if (!unregisterBukkit) {
 			// Remove nodes from the Vanilla dispatcher
 			// This dispatcher doesn't usually have namespaced version of commands (those are created when commands
 			//  are transferred to Bukkit's CommandMap), but if they ask, we'll do it
@@ -271,7 +271,7 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 			CommandAPIHandler.getInstance().writeDispatcherToFile();
 		}
 
-		if(unregisterBukkit || !CommandAPI.canRegister()) {
+		if (unregisterBukkit || !CommandAPI.canRegister()) {
 			// We need to remove commands from Bukkit's CommandMap if we're unregistering a Bukkit command, or
 			//  if we're unregistering after the server is enabled, because `CraftServer#setVanillaCommands` will have
 			//  moved the Vanilla command into the CommandMap
@@ -280,14 +280,14 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 			// If we are unregistering a Bukkit command, DO NOT unregister VanillaCommandWrappers
 			// If we are unregistering a Vanilla command, ONLY unregister VanillaCommandWrappers
 			boolean isMainVanilla = commandAPIBukkit.isVanillaCommandWrapper(knownCommands.get(commandName));
-			if(unregisterBukkit ^ isMainVanilla) knownCommands.remove(commandName);
+			if (unregisterBukkit ^ isMainVanilla) knownCommands.remove(commandName);
 
-			if(unregisterNamespaces) {
+			if (unregisterNamespaces) {
 				removeCommandNamespace(knownCommands, commandName, c -> unregisterBukkit ^ commandAPIBukkit.isVanillaCommandWrapper(c));
 			}
 		}
 
-		if(!CommandAPI.canRegister()) {
+		if (!CommandAPI.canRegister()) {
 			// If the server is enabled, we have extra cleanup to do
 
 			// Remove commands from the resources dispatcher

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/SpigotCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/SpigotCommandRegistration.java
@@ -134,7 +134,6 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 
 	@Override
 	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes) {
-
 		if (!CommandAPI.canRegister()) {
 			// Usually, when registering commands during server startup, we can just put our commands into the
 			// `net.minecraft.server.MinecraftServer#vanillaCommandDispatcher` and leave it. As the server finishes setup,
@@ -296,5 +295,10 @@ public class SpigotCommandRegistration<Source> extends CommandRegistrationStrate
 			removeBrigadierCommands(getResourcesDispatcher.get(), commandName, unregisterNamespaces,
 				c -> !unregisterBukkit ^ commandAPIBukkit.isBukkitCommandWrapper(c));
 		}
+	}
+
+	@Override
+	public void preReloadDataPacks() {
+		// Nothing to do
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/SpigotCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/SpigotCommandRegistration.java
@@ -1,0 +1,298 @@
+package dev.jorel.commandapi;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
+import dev.jorel.commandapi.preprocessor.RequireField;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.SimpleCommandMap;
+
+import java.util.*;
+
+/**
+ * Handles logic for registering commands on Spigot and old versions of Paper
+ */
+@RequireField(in = SimpleCommandMap.class, name = "knownCommands", ofType = Map.class)
+public class SpigotCommandRegistration<Source> extends CommandRegistrationStrategy<Source> {
+	private final CommandAPIBukkit<Source> commandAPIBukkit;
+
+	// References to necessary objects
+	private final CommandDispatcher<Source> brigadierDispatcher;
+	private final CommandDispatcher<Source> resourcesDispatcher;
+
+	// Namespaces
+	private final Set<String> namespacesToFix = new HashSet<>();
+	private RootCommandNode<Source> minecraftCommandNamespaces = new RootCommandNode<>();
+
+	// Reflection
+	private final SafeVarHandle<SimpleCommandMap, Map<String, Command>> commandMapKnownCommands;
+
+	public SpigotCommandRegistration(CommandAPIBukkit<Source> commandAPIBukkit, CommandDispatcher<Source> brigadierDispatcher, CommandDispatcher<Source> resourcesDispatcher) {
+		this.commandAPIBukkit = commandAPIBukkit;
+
+		this.brigadierDispatcher = brigadierDispatcher;
+		this.resourcesDispatcher = resourcesDispatcher;
+
+		this.commandMapKnownCommands = SafeVarHandle.ofOrNull(SimpleCommandMap.class, "knownCommands", "knownCommands", Map.class);
+	}
+
+	// Utility methods
+	private String unpackInternalPermissionNodeString(CommandPermission perm) {
+		final Optional<String> optionalPerm = perm.getPermission();
+		if (perm.isNegated() || perm.equals(CommandPermission.NONE) || perm.equals(CommandPermission.OP)) {
+			return "";
+		} else if (optionalPerm.isPresent()) {
+			return optionalPerm.get();
+		} else {
+			throw new IllegalStateException("Invalid permission detected: " + perm +
+				"! This should never happen - if you're seeing this message, please" +
+				"contact the developers of the CommandAPI, we'd love to know how you managed to get this error!");
+		}
+	}
+
+	// Implement CommandRegistrationStrategy methods
+	@Override
+	public CommandDispatcher<Source> getBrigadierDispatcher() {
+		return brigadierDispatcher;
+	}
+
+	@Override
+	public void runTasksAfterServerStart() {
+		// Fix namespaces first thing when starting the server
+		fixNamespaces();
+		// Sort out permissions after the server has finished registering them all
+		fixPermissions();
+	}
+
+	private void fixNamespaces() {
+		Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) commandAPIBukkit.getPaper().getCommandMap());
+
+		// Remove namespaces
+		for (String command : namespacesToFix) {
+			knownCommands.remove(command);
+			removeBrigadierCommands(resourcesDispatcher, command, false, c -> true);
+		}
+
+		// Add back certain minecraft: namespace commands
+		RootCommandNode<Source> resourcesRootNode = resourcesDispatcher.getRoot();
+		RootCommandNode<Source> brigadierRootNode = brigadierDispatcher.getRoot();
+		for (CommandNode<Source> node : minecraftCommandNamespaces.getChildren()) {
+			knownCommands.put(node.getName(), commandAPIBukkit.wrapToVanillaCommandWrapper(node));
+			resourcesRootNode.addChild(node);
+
+			// VanillaCommandWrappers in the CommandMap defer to the Brigadier dispatcher when executing.
+			// While the minecraft namespace usually does not exist in the Brigadier dispatcher, in the case of a
+			//  command conflict we do need this node to exist separately from the unnamespaced version to keep the
+			//  commands separate.
+			brigadierRootNode.addChild(node);
+		}
+		// Clear minecraftCommandNamespaces for dealing with command conflicts after the server is enabled
+		//  See `CommandAPIBukkit#postCommandRegistration`
+		minecraftCommandNamespaces = new RootCommandNode<>();
+	}
+
+	/*
+	 * Makes permission checks more "Bukkit" like and less "Vanilla Minecraft" like
+	 */
+	private void fixPermissions() {
+		// Get the command map to find registered commands
+		CommandMap map = commandAPIBukkit.getPaper().getCommandMap();
+		final Map<String, CommandPermission> permissionsToFix = CommandAPIHandler.getInstance().registeredPermissions;
+
+		if (!permissionsToFix.isEmpty()) {
+			CommandAPI.logInfo("Linking permissions to commands:");
+
+			for (Map.Entry<String, CommandPermission> entry : permissionsToFix.entrySet()) {
+				String cmdName = entry.getKey();
+				CommandPermission perm = entry.getValue();
+				CommandAPI.logInfo("  " + perm.toString() + " -> /" + cmdName);
+
+				final String permNode = unpackInternalPermissionNodeString(perm);
+
+				/*
+				 * Sets the permission. If you have to be OP to run this command, we set the
+				 * permission to null. Doing so means that Bukkit's "testPermission" will always
+				 * return true, however since the command's permission check occurs internally
+				 * via the CommandAPI, this isn't a problem.
+				 *
+				 * If anyone dares tries to use testPermission() on this command, seriously,
+				 * what are you doing and why?
+				 */
+				Command command = map.getCommand(cmdName);
+				if(command != null && commandAPIBukkit.isVanillaCommandWrapper(command)) {
+					command.setPermission(permNode);
+				}
+			}
+		}
+		CommandAPI.logNormal("Linked " + permissionsToFix.size() + " Bukkit permissions to commands");
+	}
+
+	@Override
+	public void postCommandRegistration(RegisteredCommand registeredCommand, LiteralCommandNode<Source> resultantNode, List<LiteralCommandNode<Source>> aliasNodes) {
+
+		if(!CommandAPI.canRegister()) {
+			// Usually, when registering commands during server startup, we can just put our commands into the
+			// `net.minecraft.server.MinecraftServer#vanillaCommandDispatcher` and leave it. As the server finishes setup,
+			// it and the CommandAPI do some extra stuff to make everything work, and we move on.
+			// So, if we want to register commands while the server is running, we need to do all that extra stuff, and
+			// that is what this code does.
+			// We could probably call all those methods to sync everything up, but in the spirit of avoiding side effects
+			// and avoiding doing things twice for existing commands, this is a distilled version of those methods.
+
+			Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) commandAPIBukkit.getPaper().getCommandMap());
+			RootCommandNode<Source> root = resourcesDispatcher.getRoot();
+
+			String name = resultantNode.getLiteral();
+			String namespace = registeredCommand.namespace();
+			String permNode = unpackInternalPermissionNodeString(registeredCommand.permission());
+
+			registerCommand(knownCommands, root, name, permNode, namespace, resultantNode);
+
+			// Do the same for the aliases
+			for (LiteralCommandNode<Source> node : aliasNodes) {
+				registerCommand(knownCommands, root, node.getLiteral(), permNode, namespace, node);
+			}
+
+			Collection<CommandNode<Source>> minecraftNamespacesToFix = minecraftCommandNamespaces.getChildren();
+			if (!minecraftNamespacesToFix.isEmpty()) {
+				// Adding new `minecraft` namespace nodes to the Brigadier dispatcher
+				//  usually happens in `CommandAPIBukkit#fixNamespaces`.
+				// Note that the previous calls to `CommandAPIBukkit#registerCommand` in this method
+				//  will have already dealt with adding the nodes here to the resources dispatcher.
+				// We also have to set the permission to simulate the result of `CommandAPIBukkit#fixPermissions`.
+				RootCommandNode<Source> brigadierRootNode = brigadierDispatcher.getRoot();
+				for (CommandNode<Source> node : minecraftNamespacesToFix) {
+					Command minecraftNamespaceCommand = commandAPIBukkit.wrapToVanillaCommandWrapper(node);
+					knownCommands.put(node.getName(), minecraftNamespaceCommand);
+					minecraftNamespaceCommand.setPermission(permNode);
+					brigadierRootNode.addChild(node);
+				}
+				minecraftCommandNamespaces = new RootCommandNode<>();
+			}
+		}
+	}
+
+	private void registerCommand(Map<String, Command> knownCommands, RootCommandNode<Source> root, String name, String permNode, String namespace, LiteralCommandNode<Source> resultantNode) {
+		// Wrapping Brigadier nodes into VanillaCommandWrappers and putting them in the CommandMap usually happens
+		// in `CraftServer#setVanillaCommands`
+		Command command = commandAPIBukkit.wrapToVanillaCommandWrapper(resultantNode);
+		knownCommands.putIfAbsent(name, command);
+
+		// Adding permissions to these Commands usually happens in `CommandAPIBukkit#fixPermissions`
+		command.setPermission(permNode);
+
+		// Adding commands to the other (Why bukkit/spigot?!) dispatcher usually happens in `CraftServer#syncCommands`
+		root.addChild(resultantNode);
+
+		// Handle namespace
+		LiteralCommandNode<Source> namespacedNode = CommandAPIHandler.getInstance().namespaceNode(resultantNode, namespace);
+		if (namespace.equals("minecraft")) {
+			// The minecraft namespace version should be registered as a straight alias of the original command, since
+			//  the `minecraft:name` node does not exist in the Brigadier dispatcher, which is referenced by
+			//  VanillaCommandWrapper (note this is not true if there is a command conflict, but
+			//  `CommandAPIBukkit#postCommandRegistration` will deal with this later using `minecraftCommandNamespaces`).
+			knownCommands.putIfAbsent("minecraft:" + name, command);
+		} else {
+			// A custom namespace should be registered like a separate command, so that it can reference the namespaced
+			//  node, rather than the original unnamespaced node
+			Command namespacedCommand = commandAPIBukkit.wrapToVanillaCommandWrapper(namespacedNode);
+			knownCommands.putIfAbsent(namespacedCommand.getName(), namespacedCommand);
+			namespacedCommand.setPermission(permNode);
+		}
+		// In both cases, add the node to the resources dispatcher
+		root.addChild(namespacedNode);
+	}
+
+	@Override
+	public LiteralCommandNode<Source> registerCommandNode(LiteralArgumentBuilder<Source> node, String namespace) {
+		RootCommandNode<Source> rootNode = brigadierDispatcher.getRoot();
+
+		LiteralCommandNode<Source> builtNode = node.build();
+		String name = node.getLiteral();
+		if (namespace.equals("minecraft")) {
+			if (namespacesToFix.contains("minecraft:" + name)) {
+				// This command wants to exist as `minecraft:name`
+				// However, another command has requested that `minecraft:name` be removed
+				// We'll keep track of everything that should be `minecraft:name` in
+				//  `minecraftCommandNamespaces` and fix this later in `#fixNamespaces`
+				minecraftCommandNamespaces.addChild(CommandAPIHandler.getInstance().namespaceNode(builtNode, "minecraft"));
+			}
+		} else {
+			// Make sure to remove the `minecraft:name` and
+			//  `minecraft:namespace:name` commands Bukkit will create
+			fillNamespacesToFix(name, namespace + ":" + name);
+
+			// Create the namespaced node
+			rootNode.addChild(CommandAPIHandler.getInstance().namespaceNode(builtNode, namespace));
+		}
+
+		// Add the main node to dispatcher
+		//  We needed to wait until after `fillNamespacesToFix` was called to do this, in case a previous
+		//  `minecraft:name` version of the command needed to be saved separately before this node was added
+		rootNode.addChild(builtNode);
+
+		return builtNode;
+	}
+
+	private void fillNamespacesToFix(String... namespacedCommands) {
+		for (String namespacedCommand : namespacedCommands) {
+			// We'll remove these commands later when fixNamespaces is called
+			if (!namespacesToFix.add("minecraft:" + namespacedCommand)) {
+				continue;
+			}
+
+			// If this is the first time considering this command for removal
+			// and there is already a command with this name in the dispatcher
+			// then, the command currently in the dispatcher is supposed to appear as `minecraft:command`
+			CommandNode<Source> currentNode = brigadierDispatcher.getRoot().getChild(namespacedCommand);
+			if(currentNode != null) {
+				// We'll keep track of everything that should be `minecraft:command` in
+				//  `minecraftCommandNamespaces` and fix this later in `#fixNamespaces`
+				// TODO: Ideally, we should be working without this cast to LiteralCommandNode. I don't know if this can fail
+				minecraftCommandNamespaces.addChild(CommandAPIHandler.getInstance().namespaceNode((LiteralCommandNode<Source>) currentNode, "minecraft"));
+			}
+		}
+	}
+
+	@Override
+	public void unregister(String commandName, boolean unregisterNamespaces, boolean unregisterBukkit) {
+		if(!unregisterBukkit) {
+			// Remove nodes from the Vanilla dispatcher
+			// This dispatcher doesn't usually have namespaced version of commands (those are created when commands
+			//  are transferred to Bukkit's CommandMap), but if they ask, we'll do it
+			removeBrigadierCommands(brigadierDispatcher, commandName, unregisterNamespaces, c -> true);
+
+			// Update the dispatcher file
+			CommandAPIHandler.getInstance().writeDispatcherToFile();
+		}
+
+		if(unregisterBukkit || !CommandAPI.canRegister()) {
+			// We need to remove commands from Bukkit's CommandMap if we're unregistering a Bukkit command, or
+			//  if we're unregistering after the server is enabled, because `CraftServer#setVanillaCommands` will have
+			//  moved the Vanilla command into the CommandMap
+			Map<String, Command> knownCommands = commandMapKnownCommands.get((SimpleCommandMap) commandAPIBukkit.getPaper().getCommandMap());
+
+			// If we are unregistering a Bukkit command, DO NOT unregister VanillaCommandWrappers
+			// If we are unregistering a Vanilla command, ONLY unregister VanillaCommandWrappers
+			boolean isMainVanilla = commandAPIBukkit.isVanillaCommandWrapper(knownCommands.get(commandName));
+			if(unregisterBukkit ^ isMainVanilla) knownCommands.remove(commandName);
+
+			if(unregisterNamespaces) {
+				removeCommandNamespace(knownCommands, commandName, c -> unregisterBukkit ^ commandAPIBukkit.isVanillaCommandWrapper(c));
+			}
+		}
+
+		if(!CommandAPI.canRegister()) {
+			// If the server is enabled, we have extra cleanup to do
+
+			// Remove commands from the resources dispatcher
+			// If we are unregistering a Bukkit command, ONLY unregister BukkitCommandWrappers
+			// If we are unregistering a Vanilla command, DO NOT unregister BukkitCommandWrappers
+			removeBrigadierCommands(resourcesDispatcher, commandName, unregisterNamespaces,
+				c -> !unregisterBukkit ^ commandAPIBukkit.isBukkitCommandWrapper(c));
+		}
+	}
+}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
@@ -409,30 +409,6 @@ public interface NMS<CommandListenerWrapper> {
 	Set<NamespacedKey> getTags();
 
 	/**
-	 * Checks if a Command is an instance of the OBC VanillaCommandWrapper
-	 * 
-	 * @param command The Command to check
-	 * @return true if Command is an instance of VanillaCommandWrapper
-	 */
-	boolean isVanillaCommandWrapper(Command command);
-
-	/**
-	 * Wraps a Brigadier command node as Bukkit's VanillaCommandWrapper
-	 *
-	 * @param node The LiteralCommandNode to wrap
-	 * @return A VanillaCommandWrapper representing the given node
-	 */
-	Command wrapToVanillaCommandWrapper(CommandNode<CommandListenerWrapper> node);
-
-	/**
-	 * Checks if a Brigadier command node is being handled by Bukkit's BukkitCommandWrapper
-	 *
-	 * @param node The CommandNode to check
-	 * @return true if the CommandNode is being handled by Bukkit's BukkitCommandWrapper
-	 */
-	boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node);
-
-	/**
 	 * Reloads the datapacks by using the updated the commandDispatcher tree
 	 */
 	void reloadDataPacks();

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import com.mojang.brigadier.tree.CommandNode;
 import dev.jorel.commandapi.CommandRegistrationStrategy;
 import org.bukkit.Axis;
 import org.bukkit.ChatColor;
@@ -40,7 +39,6 @@ import org.bukkit.World;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
@@ -53,7 +51,6 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Team;
 
-import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.Message;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.context.CommandContext;

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/nms/NMS.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import com.mojang.brigadier.tree.CommandNode;
+import dev.jorel.commandapi.CommandRegistrationStrategy;
 import org.bukkit.Axis;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -387,20 +388,6 @@ public interface NMS<CommandListenerWrapper> {
 	World getWorldForCSS(CommandListenerWrapper clw);
 
 	/**
-	 * Returns the Brigadier CommandDispatcher from the NMS CommandDispatcher
-	 *
-	 * @return A Brigadier CommandDispatcher
-	 */
-	CommandDispatcher<CommandListenerWrapper> getBrigadierDispatcher();
-
-	/**
-	 * Returns the Brigadier CommandDispatcher used when commands are sent to Players
-	 *
-	 * @return A Brigadier CommandDispatcher
-	 */
-	CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher();
-
-	/**
 	 * Returns the Server's internal (OBC) CommandMap
 	 * 
 	 * @return A SimpleCommandMap from the OBC server
@@ -456,4 +443,5 @@ public interface NMS<CommandListenerWrapper> {
 
 	Message generateMessageFromJson(String json);
 
+	CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy();
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 import com.mojang.brigadier.tree.CommandNode;
+import dev.jorel.commandapi.*;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -74,9 +75,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -532,13 +530,11 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 	}
 
 	@Override
-	public com.mojang.brigadier.CommandDispatcher<CommandListenerWrapper> getBrigadierDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a();
-	}
-
-	@Override
-	public CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a();
+	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
+			this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
@@ -533,7 +533,7 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
-			this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.1/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R1.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
-import com.mojang.brigadier.tree.CommandNode;
 import dev.jorel.commandapi.*;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
@@ -37,7 +36,6 @@ import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_16_R1.CraftLootTable;
@@ -530,14 +528,6 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 	}
 
 	@Override
-	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
-		);
-	}
-
-	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}
@@ -986,21 +976,6 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 		return (clw.getWorld() == null) ? null : clw.getWorld().getWorld();
 	}
 
-	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandListenerWrapper> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
 	@Differs(from = "1.15", by = "Implement datapack reloading")
 	@Override
 	public void reloadDataPacks() {
@@ -1067,4 +1042,15 @@ public class NMS_1_16_R1 extends NMSWrapper_1_16_R1 {
 		}
 	}
 
+	@Override
+	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 import com.mojang.brigadier.tree.CommandNode;
+import dev.jorel.commandapi.*;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -73,9 +74,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -530,13 +528,11 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 	}
 
 	@Override
-	public com.mojang.brigadier.CommandDispatcher<CommandListenerWrapper> getBrigadierDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a();
-	}
-
-	@Override
-	public CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a();
+	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
+			this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
@@ -531,7 +531,7 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
-			this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_R2.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
-import com.mojang.brigadier.tree.CommandNode;
 import dev.jorel.commandapi.*;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
@@ -37,7 +36,6 @@ import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_16_R2.CraftLootTable;
@@ -528,14 +526,6 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 	}
 
 	@Override
-	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
-		);
-	}
-
-	@Override
 	public BaseComponent[] getChat(CommandContext<CommandListenerWrapper> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(ChatSerializer.a(ArgumentChat.a(cmdCtx, key)));
 	}
@@ -973,21 +963,6 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 	}
 
 	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandListenerWrapper> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
-	@Override
 	public void reloadDataPacks() {
 		CommandAPI.getLogger().info("Reloading datapacks...");
 
@@ -1052,4 +1027,15 @@ public class NMS_1_16_R2 extends NMSWrapper_1_16_R2 {
 		}
 	}
 
+	@Override
+	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
@@ -41,7 +41,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
-import com.mojang.brigadier.tree.CommandNode;
 import dev.jorel.commandapi.*;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
@@ -57,7 +56,6 @@ import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_16_R3.CraftLootTable;
@@ -481,14 +479,6 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 	@Override
 	public BlockData getBlockState(CommandContext<CommandListenerWrapper> cmdCtx, String key) {
 		return CraftBlockData.fromData(ArgumentTile.a(cmdCtx, key).a());
-	}
-
-	@Override
-	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
-		);
 	}
 
 	@Override
@@ -923,21 +913,6 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 		return (clw.getWorld() == null) ? null : clw.getWorld().getWorld();
 	}
 
-	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandListenerWrapper> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandListenerWrapper> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
 	@Differs(from = "1.16.2", by = "CustomFunctionManager.g -> CustomFunctionManager.h")
 	@Override
 	public void reloadDataPacks() {
@@ -1005,4 +980,15 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 		}
 	}
 
+	@Override
+	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
@@ -42,6 +42,7 @@ import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 import com.mojang.brigadier.tree.CommandNode;
+import dev.jorel.commandapi.*;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -93,9 +94,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -486,13 +484,11 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 	}
 
 	@Override
-	public com.mojang.brigadier.CommandDispatcher<CommandListenerWrapper> getBrigadierDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a();
-	}
-
-	@Override
-	public CommandDispatcher<CommandListenerWrapper> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a();
+	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
+			this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_16_4_R3.java
@@ -487,7 +487,7 @@ public class NMS_1_16_4_R3 extends NMSWrapper_1_16_4_R3 {
 	public CommandRegistrationStrategy<CommandListenerWrapper> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.a(),
-			this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommandDispatcher().a()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
@@ -316,7 +316,7 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
-import com.mojang.brigadier.tree.CommandNode;
 import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.wrappers.*;
 import net.minecraft.advancements.critereon.MinMaxBounds;
@@ -55,7 +54,6 @@ import org.bukkit.advancement.Advancement;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_17_R1.CraftLootTable;
@@ -310,14 +308,6 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 	@Override
 	public BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key) {
 		return CraftBlockData.fromData(BlockStateArgument.getBlock(cmdCtx, key).getState());
-	}
-
-	@Override
-	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
-		);
 	}
 
 	@Override
@@ -709,21 +699,6 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 	}
 
 	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
-	@Override
 	@Unimplemented(because = NAME_CHANGED, info = "Unmapped as MinecraftServer.resources", from = "aB (1.17)", to = "aC (1.17.1)")
 	public abstract void reloadDataPacks();
 
@@ -742,4 +717,15 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 		}
 	}
 
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_17_Common.java
@@ -36,6 +36,7 @@ import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 import com.mojang.brigadier.tree.CommandNode;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.wrappers.*;
 import net.minecraft.advancements.critereon.MinMaxBounds;
 import net.minecraft.commands.arguments.*;
@@ -87,9 +88,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -315,8 +313,11 @@ public abstract class NMS_1_17_Common extends NMS_Common {
 	}
 
 	@Override
-	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
@@ -376,7 +376,7 @@ public class NMS_1_18_R2 extends NMS_Common {
 	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
@@ -38,7 +38,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
-import com.mojang.brigadier.tree.CommandNode;
 import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.wrappers.*;
 import net.minecraft.advancements.critereon.MinMaxBounds;
@@ -58,7 +57,6 @@ import org.bukkit.advancement.Advancement;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_18_R2.CraftLootTable;
@@ -370,14 +368,6 @@ public class NMS_1_18_R2 extends NMS_Common {
 	@Override
 	public BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key) {
 		return CraftBlockData.fromData(BlockStateArgument.getBlock(cmdCtx, key).getState());
-	}
-
-	@Override
-	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
-		);
 	}
 
 	@Override
@@ -753,21 +743,6 @@ public class NMS_1_18_R2 extends NMS_Common {
 		return (css.getLevel() == null) ? null : css.getLevel().getWorld();
 	}
 
-	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
 	@Differs(from = "1.18", by = "Completely rewritten way of reloading datapacks")
 	@Override
 	public void reloadDataPacks() {
@@ -902,4 +877,15 @@ public class NMS_1_18_R2 extends NMS_Common {
 		}
 	}
 
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R2.java
@@ -39,6 +39,7 @@ import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 import com.mojang.brigadier.tree.CommandNode;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.wrappers.*;
 import net.minecraft.advancements.critereon.MinMaxBounds;
 import net.minecraft.commands.arguments.*;
@@ -91,9 +92,6 @@ import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.logging.LogUtils;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -375,8 +373,11 @@ public class NMS_1_18_R2 extends NMS_Common {
 	}
 
 	@Override
-	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
@@ -38,6 +38,7 @@ import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 import com.mojang.brigadier.tree.CommandNode;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.wrappers.*;
 import net.minecraft.advancements.critereon.MinMaxBounds;
 import net.minecraft.commands.arguments.*;
@@ -87,9 +88,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -323,8 +321,11 @@ public class NMS_1_18_R1 extends NMS_Common {
 
 	@Override
 	@Differs(from = "1.17", by = "MinecraftServer#getCommands -> MinecraftServer#aA")
-	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/src/main/java/dev/jorel/commandapi/nms/NMS_1_18_R1.java
@@ -324,7 +324,7 @@ public class NMS_1_18_R1 extends NMS_Common {
 	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
@@ -33,9 +33,7 @@ import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -445,8 +443,11 @@ public abstract class NMS_1_19_Common extends NMS_CommonWithFunctions {
 
 	@Override
 	@Differs(from = "1.18", by = "MinecraftServer#aA -> MinecraftServer#aC")
-	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
@@ -31,7 +31,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
 import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
@@ -107,7 +106,6 @@ import org.bukkit.advancement.Advancement;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_19_R1.CraftLootTable;
@@ -439,15 +437,6 @@ public abstract class NMS_1_19_Common extends NMS_CommonWithFunctions {
 	@Override
 	public final BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key) {
 		return CraftBlockData.fromData(BlockStateArgument.getBlock(cmdCtx, key).getState());
-	}
-
-	@Override
-	@Differs(from = "1.18", by = "MinecraftServer#aA -> MinecraftServer#aC")
-	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
-		);
 	}
 
 	@Override
@@ -801,21 +790,6 @@ public abstract class NMS_1_19_Common extends NMS_CommonWithFunctions {
 	}
 
 	@Override
-	public final boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
-	@Override
 	public final void reloadDataPacks() {
 		CommandAPI.logNormal("Reloading datapacks...");
 
@@ -946,5 +920,18 @@ public abstract class NMS_1_19_Common extends NMS_CommonWithFunctions {
 		} else {
 			return null;
 		}
+	}
+
+	@Override
+	@Differs(from = "1.18", by = "MinecraftServer#aA -> MinecraftServer#aC")
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_Common.java
@@ -446,7 +446,7 @@ public abstract class NMS_1_19_Common extends NMS_CommonWithFunctions {
 	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
@@ -321,7 +321,7 @@ public class NMS_1_19_3_R2 extends NMS_CommonWithFunctions {
 	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
@@ -32,9 +32,7 @@ import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -320,8 +318,11 @@ public class NMS_1_19_3_R2 extends NMS_CommonWithFunctions {
 
 	@Override
 	@Differs(from = "1.19, 1.19.1, 1.19.2", by = "MinecraftServer#aC -> MinecraftServer#aB")
-	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_3_R2.java
@@ -30,7 +30,6 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
 import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
@@ -105,7 +104,6 @@ import org.bukkit.advancement.Advancement;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_19_R2.CraftLootTable;
@@ -314,15 +312,6 @@ public class NMS_1_19_3_R2 extends NMS_CommonWithFunctions {
 	@Override
 	public final BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key) {
 		return CraftBlockData.fromData(BlockStateArgument.getBlock(cmdCtx, key).getState());
-	}
-
-	@Override
-	@Differs(from = "1.19, 1.19.1, 1.19.2", by = "MinecraftServer#aC -> MinecraftServer#aB")
-	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
-		);
 	}
 
 	@Override
@@ -690,21 +679,6 @@ public class NMS_1_19_3_R2 extends NMS_CommonWithFunctions {
 		return (css.getLevel() == null) ? null : css.getLevel().getWorld();
 	}
 
-	@Override
-	public final boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
 	@Differs(from = "1.19.2", by = """
 		this.<MinecraftServer>getMinecraftServer().getWorldData().getDataPackConfig().getDisabled() -> this.<MinecraftServer>getMinecraftServer().getWorldData().getDataConfiguration().dataPacks().getDisabled()
 		Everything about this WorldDataConfiguration thingy: this.<MinecraftServer>getMinecraftServer().getWorldData().setDataConfiguration(new WorldDataConfiguration(new DataPackConfig(enabledIDs, disabledIDs), this.<MinecraftServer>getMinecraftServer().getWorldData().getDataConfiguration().enabledFeatures()));
@@ -852,4 +826,16 @@ public class NMS_1_19_3_R2 extends NMS_CommonWithFunctions {
 		return ResourceArgument.resource(COMMAND_BUILD_CONTEXT, Registries.ENTITY_TYPE);
 	}
 
+	@Override
+	@Differs(from = "1.19, 1.19.1, 1.19.2", by = "MinecraftServer#aC -> MinecraftServer#aB")
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
@@ -318,7 +318,7 @@ public class NMS_1_19_4_R3 extends NMS_CommonWithFunctions {
 	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
@@ -30,7 +30,6 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
 import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
@@ -105,7 +104,6 @@ import org.bukkit.advancement.Advancement;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_19_R3.CraftLootTable;
@@ -312,14 +310,6 @@ public class NMS_1_19_4_R3 extends NMS_CommonWithFunctions {
 	@Override
 	public final BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key) {
 		return CraftBlockData.fromData(BlockStateArgument.getBlock(cmdCtx, key).getState());
-	}
-
-	@Override
-	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
-		);
 	}
 
 	@Override
@@ -684,21 +674,6 @@ public class NMS_1_19_4_R3 extends NMS_CommonWithFunctions {
 	}
 
 	@Override
-	public final boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
-	@Override
 	public final void reloadDataPacks() {
 		CommandAPI.logNormal("Reloading datapacks...");
 
@@ -841,4 +816,15 @@ public class NMS_1_19_4_R3 extends NMS_CommonWithFunctions {
 		return ResourceArgument.resource(COMMAND_BUILD_CONTEXT, Registries.ENTITY_TYPE);
 	}
 
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_19_4_R3.java
@@ -32,9 +32,7 @@ import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -317,8 +315,11 @@ public class NMS_1_19_4_R3 extends NMS_CommonWithFunctions {
 	}
 
 	@Override
-	public CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R2.java
@@ -56,7 +56,6 @@ import org.bukkit.advancement.Advancement;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_20_R2.CraftLootTable;
@@ -87,7 +86,6 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
 
 import dev.jorel.commandapi.arguments.ArgumentSubType;
@@ -334,14 +332,6 @@ public class NMS_1_20_R2 extends NMS_CommonWithFunctions {
 	@Override
 	public final BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key) {
 		return CraftBlockData.fromData(BlockStateArgument.getBlock(cmdCtx, key).getState());
-	}
-
-	@Override
-	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
-		);
 	}
 
 	@Override
@@ -705,21 +695,6 @@ public class NMS_1_20_R2 extends NMS_CommonWithFunctions {
 	}
 
 	@Override
-	public final boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
-	@Override
 	public final void reloadDataPacks() {
 		CommandAPI.logNormal("Reloading datapacks...");
 
@@ -862,4 +837,15 @@ public class NMS_1_20_R2 extends NMS_CommonWithFunctions {
 		return ResourceArgument.resource(COMMAND_BUILD_CONTEXT, Registries.ENTITY_TYPE);
 	}
 
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R2.java
@@ -340,7 +340,7 @@ public class NMS_1_20_R2 extends NMS_CommonWithFunctions {
 	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R2.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.wrappers.*;
 import net.minecraft.advancements.critereon.MinMaxBounds;
 import net.minecraft.commands.arguments.*;
@@ -89,9 +90,6 @@ import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -339,8 +337,11 @@ public class NMS_1_20_R2 extends NMS_CommonWithFunctions {
 	}
 
 	@Override
-	public final CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R3.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
+import dev.jorel.commandapi.*;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -89,9 +90,6 @@ import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -414,8 +412,11 @@ public class NMS_1_20_R3 extends NMS_Common {
 	}
 
 	@Override
-	public final CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R3.java
@@ -415,7 +415,7 @@ public class NMS_1_20_R3 extends NMS_Common {
 	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R3.java
@@ -56,7 +56,6 @@ import org.bukkit.advancement.Advancement;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_20_R3.CraftLootTable;
@@ -87,7 +86,6 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
 
 import dev.jorel.commandapi.arguments.ArgumentSubType;
@@ -409,14 +407,6 @@ public class NMS_1_20_R3 extends NMS_Common {
 	@Override
 	public final BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key) {
 		return CraftBlockData.fromData(BlockStateArgument.getBlock(cmdCtx, key).getState());
-	}
-
-	@Override
-	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
-		);
 	}
 
 	@Override
@@ -838,21 +828,6 @@ public class NMS_1_20_R3 extends NMS_Common {
 	}
 
 	@Override
-	public final boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
-	@Override
 	public final void reloadDataPacks() {
 		CommandAPI.logNormal("Reloading datapacks...");
 
@@ -1004,4 +979,15 @@ public class NMS_1_20_R3 extends NMS_Common {
 		return ResourceArgument.resource(COMMAND_BUILD_CONTEXT, Registries.ENTITY_TYPE);
 	}
 
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
@@ -902,7 +902,7 @@ public class NMS_1_20_R4 extends NMS_Common {
 		if (vanillaCommandDispatcherFieldExists) {
 			return new SpigotCommandRegistration<>(this,
 				this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-				this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 			);
 		} else {
 			return new PaperCommandRegistration<>(this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher());

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
@@ -1059,7 +1059,19 @@ public class NMS_1_20_R4 extends NMS_Common {
 				node -> node.getCommand() instanceof BukkitCommandWrapper
 			);
 		} else {
-			return new PaperCommandRegistration<>(() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher());
+			// This class is Paper-server specific, so we need to use paper's userdev plugin to
+			//  access it directly. That might need gradle, but there might also be a maven version?
+			//  https://discord.com/channels/289587909051416579/1121227200277004398/1246910745761812480
+			Class<?> bukkitCommandNode_bukkitBrigCommand;
+			try {
+				bukkitCommandNode_bukkitBrigCommand = Class.forName("io.papermc.paper.command.brigadier.bukkit.BukkitCommandNode$BukkitBrigCommand");
+			} catch (ClassNotFoundException e) {
+				throw new IllegalStateException("Expected to find class", e);
+			}
+			return new PaperCommandRegistration<>(
+				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
+			);
 		}
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
@@ -905,7 +905,7 @@ public class NMS_1_20_R4 extends NMS_Common {
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 			);
 		} else {
-			return new PaperCommandRegistration<>(this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher());
+			return new PaperCommandRegistration<>(() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher());
 		}
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
@@ -30,7 +30,6 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
 import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
@@ -106,7 +105,6 @@ import org.bukkit.advancement.Advancement;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_20_R1.CraftLootTable;
@@ -311,14 +309,6 @@ public class NMS_1_20_R1 extends NMS_CommonWithFunctions {
 	@Override
 	public final BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key) {
 		return CraftBlockData.fromData(BlockStateArgument.getBlock(cmdCtx, key).getState());
-	}
-
-	@Override
-	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this,
-			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
-		);
 	}
 
 	@Override
@@ -684,21 +674,6 @@ public class NMS_1_20_R1 extends NMS_CommonWithFunctions {
 	}
 
 	@Override
-	public final boolean isVanillaCommandWrapper(Command command) {
-		return command instanceof VanillaCommandWrapper;
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return node.getCommand() instanceof BukkitCommandWrapper;
-	}
-
-	@Override
 	public final void reloadDataPacks() {
 		CommandAPI.logNormal("Reloading datapacks...");
 
@@ -841,4 +816,15 @@ public class NMS_1_20_R1 extends NMS_CommonWithFunctions {
 		return ResourceArgument.resource(COMMAND_BUILD_CONTEXT, Registries.ENTITY_TYPE);
 	}
 
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			(SimpleCommandMap) getPaper().getCommandMap(),
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+			command -> command instanceof VanillaCommandWrapper,
+			node -> new VanillaCommandWrapper(this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher, node),
+			node -> node.getCommand() instanceof BukkitCommandWrapper
+		);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
@@ -317,7 +317,7 @@ public class NMS_1_20_R1 extends NMS_CommonWithFunctions {
 	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
 		return new SpigotCommandRegistration<>(this,
 			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
-			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+			() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
 		);
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R1.java
@@ -32,9 +32,7 @@ import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.logging.LogUtils;
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIHandler;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.arguments.ArgumentSubType;
 import dev.jorel.commandapi.arguments.SuggestionProviders;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
@@ -316,8 +314,11 @@ public class NMS_1_20_R1 extends NMS_CommonWithFunctions {
 	}
 
 	@Override
-	public final CommandDispatcher<CommandSourceStack> getResourcesDispatcher() {
-		return this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher();
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this,
+			this.<MinecraftServer>getMinecraftServer().vanillaCommandDispatcher.getDispatcher(),
+			this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher()
+		);
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/src/main/java/dev/jorel/commandapi/nms/NMS_Common.java
@@ -25,7 +25,6 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
-import com.mojang.brigadier.tree.CommandNode;
 import dev.jorel.commandapi.CommandAPIBukkit;
 import dev.jorel.commandapi.CommandAPIHandler;
 import dev.jorel.commandapi.CommandRegistrationStrategy;
@@ -53,7 +52,6 @@ import net.minecraft.world.phys.Vec2;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.enchantments.Enchantment;
@@ -348,10 +346,6 @@ public abstract class NMS_Common extends CommandAPIBukkit<CommandSourceStack> {
 	public abstract BlockData getBlockState(CommandContext<CommandSourceStack> cmdCtx, String key);
 
 	@Override
-	@Unimplemented(because = NAME_CHANGED, info = "MinecraftServer#getCommands() obfuscated differently across multiple versions")
-	public abstract CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy();
-
-	@Override
 	@Overridden(in = "1.20.5", because = "Serializer.toJson now needs a Provider")
 	public BaseComponent[] getChat(CommandContext<CommandSourceStack> cmdCtx, String key) throws CommandSyntaxException {
 		return ComponentSerializer.parse(Serializer.toJson(MessageArgument.getMessage(cmdCtx, key)));
@@ -583,18 +577,12 @@ public abstract class NMS_Common extends CommandAPIBukkit<CommandSourceStack> {
 	}
 
 	@Override
-	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "VanillaCommandWrapper")
-	public abstract boolean isVanillaCommandWrapper(Command command);
-
-	@Override
-	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "VanillaCommandWrapper")
-	public abstract Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node);
-
-	@Override
-	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "VanillaCommandWrapper")
-	public abstract boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node);
-
-	@Override
 	@Unimplemented(because = VERSION_SPECIFIC_IMPLEMENTATION)
 	public abstract void reloadDataPacks();
+
+	@Override
+	@Unimplemented(because = NAME_CHANGED, info = "MinecraftServer#getCommands() obfuscated differently across multiple versions")
+	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "VanillaCommandWrapper")
+	@Unimplemented(because = REQUIRES_CRAFTBUKKIT, classNamed = "BukkitCommandWrapper")
+	public abstract CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy();
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import dev.jorel.commandapi.arguments.BooleanArgument;
 import dev.jorel.commandapi.arguments.StringArgument;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -133,16 +134,34 @@ public class CommandAPIMain extends JavaPlugin {
 	public void onEnable() {
 		CommandAPI.onEnable();
 
+		// TODO: Remove these commands
 		new CommandAPICommand("register")
 			.withArguments(new StringArgument("name"))
+			.withOptionalArguments(new StringArgument("namespace"))
 			.executes(info -> {
 				String name = info.args().getUnchecked("name");
+				String namespace = info.args().getOrDefaultUnchecked("namespace", "minecraft");
 
 				new CommandAPICommand(name)
 					.executes(subinfo -> {
 						subinfo.sender().sendMessage("You ran the " + name + " command");
 					})
-					.register();
+					.register(namespace);
+			})
+			.register();
+
+		new CommandAPICommand("unregister")
+			.withArguments(new StringArgument("name"))
+			.withOptionalArguments(
+				new BooleanArgument("unregisterNamespaces"),
+				new BooleanArgument("unregisterBukkit")
+			)
+			.executes(info -> {
+				String name = info.args().getUnchecked("name");
+				boolean unregisterNamespaces = info.args().getOrDefaultUnchecked("unregisterNamespaces", false);
+				boolean unregisterBukkit = info.args().getOrDefaultUnchecked("unregisterBukkit", false);
+
+				CommandAPIBukkit.unregister(name, unregisterNamespaces, unregisterBukkit);
 			})
 			.register();
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import dev.jorel.commandapi.arguments.BooleanArgument;
-import dev.jorel.commandapi.arguments.StringArgument;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.InvalidPluginException;
@@ -133,36 +131,5 @@ public class CommandAPIMain extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		CommandAPI.onEnable();
-
-		// TODO: Remove these commands
-		new CommandAPICommand("register")
-			.withArguments(new StringArgument("name"))
-			.withOptionalArguments(new StringArgument("namespace"))
-			.executes(info -> {
-				String name = info.args().getUnchecked("name");
-				String namespace = info.args().getOrDefaultUnchecked("namespace", "minecraft");
-
-				new CommandAPICommand(name)
-					.executes(subinfo -> {
-						subinfo.sender().sendMessage("You ran the " + name + " command");
-					})
-					.register(namespace);
-			})
-			.register();
-
-		new CommandAPICommand("unregister")
-			.withArguments(new StringArgument("name"))
-			.withOptionalArguments(
-				new BooleanArgument("unregisterNamespaces"),
-				new BooleanArgument("unregisterBukkit")
-			)
-			.executes(info -> {
-				String name = info.args().getUnchecked("name");
-				boolean unregisterNamespaces = info.args().getOrDefaultUnchecked("unregisterNamespaces", false);
-				boolean unregisterBukkit = info.args().getOrDefaultUnchecked("unregisterBukkit", false);
-
-				CommandAPIBukkit.unregister(name, unregisterNamespaces, unregisterBukkit);
-			})
-			.register();
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import dev.jorel.commandapi.arguments.StringArgument;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.InvalidPluginException;
@@ -131,5 +132,18 @@ public class CommandAPIMain extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		CommandAPI.onEnable();
+
+		new CommandAPICommand("register")
+			.withArguments(new StringArgument("name"))
+			.executes(info -> {
+				String name = info.args().getUnchecked("name");
+
+				new CommandAPICommand(name)
+					.executes(subinfo -> {
+						subinfo.sender().sendMessage("You ran the " + name + " command");
+					})
+					.register();
+			})
+			.register();
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -11,8 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
-import com.mojang.brigadier.tree.CommandNode;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import net.minecraft.commands.Commands;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -20,7 +19,6 @@ import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.World;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_17_R1.CraftParticle;
@@ -45,8 +43,6 @@ import com.mojang.brigadier.context.CommandContext;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.enchantments.EnchantmentMock;
 import be.seeseemelk.mockbukkit.potion.MockPotionEffectType;
-import dev.jorel.commandapi.Brigadier;
-import dev.jorel.commandapi.CommandAPIBukkit;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitPlayer;
@@ -103,10 +99,19 @@ public class MockNMS extends Enums {
 	public MockNMS(CommandAPIBukkit<?> baseNMS) {
 		super(baseNMS);
 
-		// Stub in our getMinecraftServer implementation
 		CommandAPIBukkit<CommandSourceStack> nms = Mockito.spy(super.baseNMS);
+		// Stub in our getMinecraftServer implementation
 		Mockito.when(nms.getMinecraftServer()).thenAnswer(i -> getMinecraftServer());
+		// Stub in our getSimpleCommandMap implementation
+		//  Note that calling `nms.getSimpleCommandMap()` throws a
+		//  class cast exception  (`CraftServer` vs `CommandAPIServerMock`),
+		//  so we have to mock with `doAnswer` instead of `when`
+		Mockito.doAnswer(i -> getSimpleCommandMap()).when(nms).getSimpleCommandMap();
 		super.baseNMS = nms;
+
+		// Initialize baseNMS's paper field (with paper specific implementations disabled)
+		MockPlatform.setField(CommandAPIBukkit.class, "paper",
+			super.baseNMS, new PaperImplementations(false, false, super.baseNMS));
 
 		// Initialize WorldVersion (game version)
 		SharedConstants.tryDetectVersion();
@@ -253,21 +258,6 @@ public class MockNMS extends Enums {
 	@Override
 	public SimpleCommandMap getSimpleCommandMap() {
 		return ((ServerMock) Bukkit.getServer()).getCommandMap();
-	}
-
-	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return baseNMS.isVanillaCommandWrapper(command);
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.wrapToVanillaCommandWrapper(node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@Override
@@ -529,10 +519,16 @@ public class MockNMS extends Enums {
 		Mockito.when(minecraftServerMock.getGameRules()).thenAnswer(i -> new GameRules());
 		Mockito.when(minecraftServerMock.getProfiler()).thenAnswer(i -> InactiveMetricsRecorder.INSTANCE.getProfiler());
 
-		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
-		Commands commands = new Commands();
-		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		// Brigadier and resources dispatcher, used in `NMS#createCommandRegistrationStrategy`
+		Commands brigadierCommands = new Commands();
+		MockPlatform.setField(brigadierCommands.getClass(), "g", "dispatcher",
+			brigadierCommands, getMockBrigadierDispatcher());
+		minecraftServerMock.vanillaCommandDispatcher = brigadierCommands;
+
+		Commands resourcesCommands = new Commands();
+		MockPlatform.setField(resourcesCommands.getClass(), "g", "dispatcher",
+			resourcesCommands, getMockResourcesDispatcher());
+		Mockito.when(minecraftServerMock.getCommands()).thenReturn(resourcesCommands);
 
 		return (T) minecraftServerMock;
 	}
@@ -639,5 +635,10 @@ public class MockNMS extends Enums {
 	@Override
 	public Map<String, HelpTopic> getHelpMap() {
 		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
+
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return baseNMS.createCommandRegistrationStrategy();
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -12,8 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
-import com.mojang.brigadier.tree.CommandNode;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import net.minecraft.commands.Commands;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -21,7 +20,6 @@ import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.World;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_18_R1.CraftParticle;
@@ -49,8 +47,6 @@ import com.mojang.brigadier.context.CommandContext;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.enchantments.EnchantmentMock;
 import be.seeseemelk.mockbukkit.potion.MockPotionEffectType;
-import dev.jorel.commandapi.Brigadier;
-import dev.jorel.commandapi.CommandAPIBukkit;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitPlayer;
@@ -118,10 +114,19 @@ public class MockNMS extends Enums {
 	public MockNMS(CommandAPIBukkit<?> baseNMS) {
 		super(baseNMS);
 
-		// Stub in our getMinecraftServer implementation
 		CommandAPIBukkit<CommandSourceStack> nms = Mockito.spy(super.baseNMS);
+		// Stub in our getMinecraftServer implementation
 		Mockito.when(nms.getMinecraftServer()).thenAnswer(i -> getMinecraftServer());
+		// Stub in our getSimpleCommandMap implementation
+		//  Note that calling `nms.getSimpleCommandMap()` throws a
+		//  class cast exception  (`CraftServer` vs `CommandAPIServerMock`),
+		//  so we have to mock with `doAnswer` instead of `when`
+		Mockito.doAnswer(i -> getSimpleCommandMap()).when(nms).getSimpleCommandMap();
 		super.baseNMS = nms;
+
+		// Initialize baseNMS's paper field (with paper specific implementations disabled)
+		MockPlatform.setField(CommandAPIBukkit.class, "paper",
+			super.baseNMS, new PaperImplementations(false, false, super.baseNMS));
 
 		// Initialize WorldVersion (game version)
 		SharedConstants.tryDetectVersion();
@@ -270,21 +275,6 @@ public class MockNMS extends Enums {
 	@Override
 	public SimpleCommandMap getSimpleCommandMap() {
 		return ((ServerMock) Bukkit.getServer()).getCommandMap();
-	}
-
-	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return baseNMS.isVanillaCommandWrapper(command);
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.wrapToVanillaCommandWrapper(node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@SuppressWarnings({ "deprecation", "unchecked" })
@@ -544,10 +534,16 @@ public class MockNMS extends Enums {
 		Mockito.when(minecraftServerMock.getGameRules()).thenAnswer(i -> new GameRules());
 		Mockito.when(minecraftServerMock.getProfiler()).thenAnswer(i -> InactiveMetricsRecorder.INSTANCE.getProfiler());
 
-		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
-		Commands commands = new Commands();
-		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		// Brigadier and resources dispatcher, used in `NMS#createCommandRegistrationStrategy`
+		Commands brigadierCommands = new Commands();
+		MockPlatform.setField(brigadierCommands.getClass(), "g", "dispatcher",
+			brigadierCommands, getMockBrigadierDispatcher());
+		minecraftServerMock.vanillaCommandDispatcher = brigadierCommands;
+
+		Commands resourcesCommands = new Commands();
+		MockPlatform.setField(resourcesCommands.getClass(), "g", "dispatcher",
+			resourcesCommands, getMockResourcesDispatcher());
+		Mockito.when(minecraftServerMock.getCommands()).thenReturn(resourcesCommands);
 
 		return (T) minecraftServerMock;
 	}
@@ -674,5 +670,10 @@ public class MockNMS extends Enums {
 	@Override
 	public Map<String, HelpTopic> getHelpMap() {
 		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
+
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return baseNMS.createCommandRegistrationStrategy();
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -12,8 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import be.seeseemelk.mockbukkit.help.HelpMapMock;
-import com.mojang.brigadier.tree.CommandNode;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import net.minecraft.commands.Commands;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -21,7 +20,6 @@ import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.World;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_19_R3.CraftParticle;
@@ -49,8 +47,6 @@ import com.mojang.brigadier.context.CommandContext;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.enchantments.EnchantmentMock;
 import be.seeseemelk.mockbukkit.potion.MockPotionEffectType;
-import dev.jorel.commandapi.Brigadier;
-import dev.jorel.commandapi.CommandAPIBukkit;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitPlayer;
@@ -113,10 +109,19 @@ public class MockNMS extends Enums {
 	public MockNMS(CommandAPIBukkit<?> baseNMS) {
 		super(baseNMS);
 
-		// Stub in our getMinecraftServer implementation
 		CommandAPIBukkit<CommandSourceStack> nms = Mockito.spy(super.baseNMS);
+		// Stub in our getMinecraftServer implementation
 		Mockito.when(nms.getMinecraftServer()).thenAnswer(i -> getMinecraftServer());
+		// Stub in our getSimpleCommandMap implementation
+		//  Note that calling `nms.getSimpleCommandMap()` throws a
+		//  class cast exception  (`CraftServer` vs `CommandAPIServerMock`),
+		//  so we have to mock with `doAnswer` instead of `when`
+		Mockito.doAnswer(i -> getSimpleCommandMap()).when(nms).getSimpleCommandMap();
 		super.baseNMS = nms;
+
+		// Initialize baseNMS's paper field (with paper specific implementations disabled)
+		MockPlatform.setField(CommandAPIBukkit.class, "paper",
+			super.baseNMS, new PaperImplementations(false, false, super.baseNMS));
 
 //		initializeArgumentsInArgumentTypeInfos();
 
@@ -267,21 +272,6 @@ public class MockNMS extends Enums {
 	@Override
 	public SimpleCommandMap getSimpleCommandMap() {
 		return ((ServerMock) Bukkit.getServer()).getCommandMap();
-	}
-
-	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return baseNMS.isVanillaCommandWrapper(command);
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.wrapToVanillaCommandWrapper(node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@SuppressWarnings({ "deprecation", "unchecked" })
@@ -547,10 +537,16 @@ public class MockNMS extends Enums {
 		Mockito.when(minecraftServerMock.getGameRules()).thenAnswer(i -> new GameRules());
 		Mockito.when(minecraftServerMock.getProfiler()).thenAnswer(i -> InactiveMetricsRecorder.INSTANCE.getProfiler());
 
-		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
-		Commands commands = new Commands();
-		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		// Brigadier and resources dispatcher, used in `NMS#createCommandRegistrationStrategy`
+		Commands brigadierCommands = new Commands();
+		MockPlatform.setField(brigadierCommands.getClass(), "g", "dispatcher",
+			brigadierCommands, getMockBrigadierDispatcher());
+		minecraftServerMock.vanillaCommandDispatcher = brigadierCommands;
+
+		Commands resourcesCommands = new Commands();
+		MockPlatform.setField(resourcesCommands.getClass(), "g", "dispatcher",
+			resourcesCommands, getMockResourcesDispatcher());
+		Mockito.when(minecraftServerMock.getCommands()).thenReturn(resourcesCommands);
 
 		return (T) minecraftServerMock;
 	}
@@ -865,5 +861,10 @@ public class MockNMS extends Enums {
 	@Override
 	public Map<String, HelpTopic> getHelpMap() {
 		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
+
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return baseNMS.createCommandRegistrationStrategy();
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.3/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.3/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -1,64 +1,15 @@
 package dev.jorel.commandapi.test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-
-import java.io.File;
-import java.io.IOException;
-import java.security.CodeSource;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.Stack;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
-import org.bukkit.Particle;
-import org.bukkit.World;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.SimpleCommandMap;
-import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
-import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer;
-import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemFactory;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.help.HelpTopic;
-import org.bukkit.inventory.ItemFactory;
-import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scoreboard.Team;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.mockito.Mockito;
-
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.enchantments.EnchantmentMock;
+import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.google.common.collect.Streams;
 import com.google.gson.JsonParseException;
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.serialization.JsonOps;
-
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.enchantments.EnchantmentMock;
-import be.seeseemelk.mockbukkit.help.HelpMapMock;
-import dev.jorel.commandapi.Brigadier;
-import dev.jorel.commandapi.CommandAPIBukkit;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitPlayer;
@@ -75,12 +26,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.numbers.BlankFormat;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.Bootstrap;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.ServerAdvancementManager;
-import net.minecraft.server.ServerFunctionLibrary;
-import net.minecraft.server.ServerFunctionManager;
-import net.minecraft.server.ServerScoreboard;
+import net.minecraft.server.*;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.GameProfileCache;
@@ -100,6 +46,32 @@ import net.minecraft.world.scores.Objective;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria.RenderType;
+import org.bukkit.*;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemFactory;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.help.HelpTopic;
+import org.bukkit.inventory.ItemFactory;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scoreboard.Team;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.CodeSource;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.mockito.ArgumentMatchers.*;
 
 public class MockNMS extends Enums {
 	private static final SafeVarHandle<HelpMapMock, Map<String, HelpTopic>> helpMapTopics =
@@ -125,10 +97,19 @@ public class MockNMS extends Enums {
 	public MockNMS(CommandAPIBukkit<?> baseNMS) {
 		super(baseNMS);
 
-		// Stub in our getMinecraftServer implementation
 		CommandAPIBukkit<CommandSourceStack> nms = Mockito.spy(super.baseNMS);
+		// Stub in our getMinecraftServer implementation
 		Mockito.when(nms.getMinecraftServer()).thenAnswer(i -> getMinecraftServer());
+		// Stub in our getSimpleCommandMap implementation
+		//  Note that calling `nms.getSimpleCommandMap()` throws a
+		//  class cast exception  (`CraftServer` vs `CommandAPIServerMock`),
+		//  so we have to mock with `doAnswer` instead of `when`
+		Mockito.doAnswer(i -> getSimpleCommandMap()).when(nms).getSimpleCommandMap();
 		super.baseNMS = nms;
+
+		// Initialize baseNMS's paper field (with paper specific implementations disabled)
+		MockPlatform.setField(CommandAPIBukkit.class, "paper",
+			super.baseNMS, new PaperImplementations(false, false, super.baseNMS));
 
 //		initializeArgumentsInArgumentTypeInfos();
 
@@ -284,21 +265,6 @@ public class MockNMS extends Enums {
 	@Override
 	public SimpleCommandMap getSimpleCommandMap() {
 		return ((ServerMock) Bukkit.getServer()).getCommandMap();
-	}
-
-	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return baseNMS.isVanillaCommandWrapper(command);
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.wrapToVanillaCommandWrapper(node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@SuppressWarnings({ "deprecation", "unchecked" })
@@ -581,10 +547,16 @@ public class MockNMS extends Enums {
 		Mockito.when(minecraftServerMock.getGameRules()).thenAnswer(i -> new GameRules());
 		Mockito.when(minecraftServerMock.getProfiler()).thenAnswer(i -> InactiveMetricsRecorder.INSTANCE.getProfiler());
 
-		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
-		Commands commands = new Commands();
-		MockPlatform.setField(commands.getClass(), "h", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		// Brigadier and resources dispatcher, used in `NMS#createCommandRegistrationStrategy`
+		Commands brigadierCommands = new Commands();
+		MockPlatform.setField(brigadierCommands.getClass(), "h", "dispatcher",
+			brigadierCommands, getMockBrigadierDispatcher());
+		minecraftServerMock.vanillaCommandDispatcher = brigadierCommands;
+
+		Commands resourcesCommands = new Commands();
+		MockPlatform.setField(resourcesCommands.getClass(), "h", "dispatcher",
+			resourcesCommands, getMockResourcesDispatcher());
+		Mockito.when(minecraftServerMock.getCommands()).thenReturn(resourcesCommands);
 
 		return (T) minecraftServerMock;
 	}
@@ -907,5 +879,10 @@ public class MockNMS extends Enums {
 	@Override
 	public Map<String, HelpTopic> getHelpMap() {
 		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
+
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return baseNMS.createCommandRegistrationStrategy();
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.5/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -1,64 +1,13 @@
 package dev.jorel.commandapi.test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-
-import java.io.File;
-import java.io.IOException;
-import java.security.CodeSource;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.Stack;
-import java.util.UUID;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
-import org.bukkit.Particle;
-import org.bukkit.World;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.SimpleCommandMap;
-import org.bukkit.craftbukkit.v1_20_R4.CraftParticle;
-import org.bukkit.craftbukkit.v1_20_R4.CraftRegistry;
-import org.bukkit.craftbukkit.v1_20_R4.CraftWorld;
-import org.bukkit.craftbukkit.v1_20_R4.entity.CraftPlayer;
-import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftItemFactory;
-import org.bukkit.craftbukkit.v1_20_R4.util.CraftNamespacedKey;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-import org.bukkit.help.HelpTopic;
-import org.bukkit.inventory.ItemFactory;
-import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scoreboard.Team;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import com.google.gson.JsonParseException;
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.serialization.JsonOps;
-
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.help.HelpMapMock;
-import dev.jorel.commandapi.Brigadier;
-import dev.jorel.commandapi.CommandAPIBukkit;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitPlayer;
@@ -71,21 +20,13 @@ import net.minecraft.commands.arguments.EntityAnchorArgument.Anchor;
 import net.minecraft.commands.functions.CommandFunction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.numbers.BlankFormat;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.Bootstrap;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.ServerAdvancementManager;
-import net.minecraft.server.ServerFunctionLibrary;
-import net.minecraft.server.ServerFunctionManager;
-import net.minecraft.server.ServerScoreboard;
+import net.minecraft.server.*;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.GameProfileCache;
@@ -103,6 +44,32 @@ import net.minecraft.world.scores.Objective;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria.RenderType;
+import org.bukkit.*;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.craftbukkit.v1_20_R4.CraftRegistry;
+import org.bukkit.craftbukkit.v1_20_R4.CraftWorld;
+import org.bukkit.craftbukkit.v1_20_R4.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftItemFactory;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.help.HelpTopic;
+import org.bukkit.inventory.ItemFactory;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scoreboard.Team;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.CodeSource;
+import java.util.*;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.mockito.ArgumentMatchers.*;
 
 public class MockNMS extends Enums {
 	private static final SafeVarHandle<HelpMapMock, Map<String, HelpTopic>> helpMapTopics =
@@ -128,10 +95,19 @@ public class MockNMS extends Enums {
 	public MockNMS(CommandAPIBukkit<?> baseNMS) {
 		super(baseNMS);
 
-		// Stub in our getMinecraftServer implementation
 		CommandAPIBukkit<CommandSourceStack> nms = Mockito.spy(super.baseNMS);
+		// Stub in our getMinecraftServer implementation
 		Mockito.when(nms.getMinecraftServer()).thenAnswer(i -> getMinecraftServer());
+		// Stub in our getSimpleCommandMap implementation
+		//  Note that calling `nms.getSimpleCommandMap()` throws a
+		//  class cast exception  (`CraftServer` vs `CommandAPIServerMock`),
+		//  so we have to mock with `doAnswer` instead of `when`
+		Mockito.doAnswer(i -> getSimpleCommandMap()).when(nms).getSimpleCommandMap();
 		super.baseNMS = nms;
+
+		// Initialize baseNMS's paper field (with paper specific implementations disabled)
+		MockPlatform.setField(CommandAPIBukkit.class, "paper",
+			super.baseNMS, new PaperImplementations(false, false, super.baseNMS));
 
 //		initializeArgumentsInArgumentTypeInfos();
 
@@ -308,21 +284,6 @@ public class MockNMS extends Enums {
 	@Override
 	public SimpleCommandMap getSimpleCommandMap() {
 		return ((ServerMock) Bukkit.getServer()).getCommandMap();
-	}
-
-	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return baseNMS.isVanillaCommandWrapper(command);
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.wrapToVanillaCommandWrapper(node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@SuppressWarnings({ "deprecation", "unchecked" })
@@ -715,10 +676,16 @@ public class MockNMS extends Enums {
 		Mockito.when(minecraftServerMock.getGameRules()).thenAnswer(i -> new GameRules());
 		Mockito.when(minecraftServerMock.getProfiler()).thenAnswer(i -> InactiveMetricsRecorder.INSTANCE.getProfiler());
 
-		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
-		Commands commands = new Commands();
-		MockPlatform.setField(commands.getClass(), "h", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		// Brigadier and resources dispatcher, used in `NMS#createCommandRegistrationStrategy`
+		Commands brigadierCommands = new Commands();
+		MockPlatform.setField(brigadierCommands.getClass(), "h", "dispatcher",
+			brigadierCommands, getMockBrigadierDispatcher());
+		minecraftServerMock.vanillaCommandDispatcher = brigadierCommands;
+
+		Commands resourcesCommands = new Commands();
+		MockPlatform.setField(resourcesCommands.getClass(), "h", "dispatcher",
+			resourcesCommands, getMockResourcesDispatcher());
+		Mockito.when(minecraftServerMock.getCommands()).thenReturn(resourcesCommands);
 
 		return (T) minecraftServerMock;
 	}
@@ -1041,5 +1008,10 @@ public class MockNMS extends Enums {
 	@Override
 	public Map<String, HelpTopic> getHelpMap() {
 		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
+
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return baseNMS.createCommandRegistrationStrategy();
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/src/main/java/dev/jorel/commandapi/test/MockNMS.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/src/main/java/dev/jorel/commandapi/test/MockNMS.java
@@ -8,10 +8,7 @@ import com.google.common.collect.Streams;
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.tree.CommandNode;
-import dev.jorel.commandapi.Brigadier;
-import dev.jorel.commandapi.CommandAPIBukkit;
-import dev.jorel.commandapi.SafeVarHandle;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.commandsenders.AbstractCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitCommandSender;
 import dev.jorel.commandapi.commandsenders.BukkitPlayer;
@@ -46,7 +43,6 @@ import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria.RenderType;
 import org.bukkit.*;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.craftbukkit.v1_20_R1.CraftParticle;
@@ -97,10 +93,19 @@ public class MockNMS extends Enums {
 	public MockNMS(CommandAPIBukkit<?> baseNMS) {
 		super(baseNMS);
 
-		// Stub in our getMinecraftServer implementation
 		CommandAPIBukkit<CommandSourceStack> nms = Mockito.spy(super.baseNMS);
+		// Stub in our getMinecraftServer implementation
 		Mockito.when(nms.getMinecraftServer()).thenAnswer(i -> getMinecraftServer());
+		// Stub in our getSimpleCommandMap implementation
+		//  Note that calling `nms.getSimpleCommandMap()` throws a
+		//  class cast exception  (`CraftServer` vs `CommandAPIServerMock`),
+		//  so we have to mock with `doAnswer` instead of `when`
+		Mockito.doAnswer(i -> getSimpleCommandMap()).when(nms).getSimpleCommandMap();
 		super.baseNMS = nms;
+
+		// Initialize baseNMS's paper field (with paper specific implementations disabled)
+		MockPlatform.setField(CommandAPIBukkit.class, "paper",
+			super.baseNMS, new PaperImplementations(false, false, super.baseNMS));
 
 //		initializeArgumentsInArgumentTypeInfos();
 
@@ -251,21 +256,6 @@ public class MockNMS extends Enums {
 	@Override
 	public SimpleCommandMap getSimpleCommandMap() {
 		return ((ServerMock) Bukkit.getServer()).getCommandMap();
-	}
-
-	@Override
-	public boolean isVanillaCommandWrapper(Command command) {
-		return baseNMS.isVanillaCommandWrapper(command);
-	}
-
-	@Override
-	public Command wrapToVanillaCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.wrapToVanillaCommandWrapper(node);
-	}
-
-	@Override
-	public boolean isBukkitCommandWrapper(CommandNode<CommandSourceStack> node) {
-		return baseNMS.isBukkitCommandWrapper(node);
 	}
 
 	@SuppressWarnings({ "deprecation", "unchecked" })
@@ -545,10 +535,16 @@ public class MockNMS extends Enums {
 		Mockito.when(minecraftServerMock.getGameRules()).thenAnswer(i -> new GameRules());
 		Mockito.when(minecraftServerMock.getProfiler()).thenAnswer(i -> InactiveMetricsRecorder.INSTANCE.getProfiler());
 
-		// Commands object, used when creating VanillaCommandWrappers in NMS#wrapToVanillaCommandWrapper
-		Commands commands = new Commands();
-		MockPlatform.setField(commands.getClass(), "g", "dispatcher", commands, getBrigadierDispatcher());
-		minecraftServerMock.vanillaCommandDispatcher = commands;
+		// Brigadier and resources dispatcher, used in `NMS#createCommandRegistrationStrategy`
+		Commands brigadierCommands = new Commands();
+		MockPlatform.setField(brigadierCommands.getClass(), "g", "dispatcher",
+			brigadierCommands, getMockBrigadierDispatcher());
+		minecraftServerMock.vanillaCommandDispatcher = brigadierCommands;
+
+		Commands resourcesCommands = new Commands();
+		MockPlatform.setField(resourcesCommands.getClass(), "g", "dispatcher",
+			resourcesCommands, getMockResourcesDispatcher());
+		Mockito.when(minecraftServerMock.getCommands()).thenReturn(resourcesCommands);
 
 		return (T) minecraftServerMock;
 	}
@@ -863,5 +859,10 @@ public class MockNMS extends Enums {
 	@Override
 	public Map<String, HelpTopic> getHelpMap() {
 		return helpMapTopics.get((HelpMapMock) Bukkit.getHelpMap());
+	}
+
+	@Override
+	public CommandRegistrationStrategy<CommandSourceStack> createCommandRegistrationStrategy() {
+		return baseNMS.createCommandRegistrationStrategy();
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
@@ -66,15 +66,14 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 	 * CommandAPIBukkit implementations *
 	 ************************************/
 
-	private final CommandDispatcher<CLW> dispatcher = new CommandDispatcher<>();
+	private final CommandDispatcher<CLW> brigadierDispatcher = new CommandDispatcher<>();
 	private final CommandDispatcher<CLW> resourcesDispatcher = new CommandDispatcher<>();
 
-	@Override
-	public CommandRegistrationStrategy<CLW> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this, dispatcher, () -> resourcesDispatcher);
+	public CommandDispatcher<CLW> getMockBrigadierDispatcher() {
+		return brigadierDispatcher;
 	}
 
-	public CommandDispatcher<CLW> getResourcesDispatcher() {
+	public CommandDispatcher<CLW> getMockResourcesDispatcher() {
 		return resourcesDispatcher;
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
@@ -14,8 +14,6 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import dev.jorel.commandapi.CommandRegistrationStrategy;
-import dev.jorel.commandapi.SpigotCommandRegistration;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
@@ -14,6 +14,8 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import dev.jorel.commandapi.CommandRegistrationStrategy;
+import dev.jorel.commandapi.SpigotCommandRegistration;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
@@ -64,23 +66,16 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 	 * CommandAPIBukkit implementations *
 	 ************************************/
 
-	private CommandDispatcher<CLW> dispatcher = null;
-	private CommandDispatcher<CLW> resourcesDispatcher = null;
+	private final CommandDispatcher<CLW> dispatcher = new CommandDispatcher<>();
+	private final CommandDispatcher<CLW> resourcesDispatcher = new CommandDispatcher<>();
 
 	@Override
-	public final CommandDispatcher<CLW> getBrigadierDispatcher() {
-		if (this.dispatcher == null) {
-			this.dispatcher = new CommandDispatcher<>();
-		}
-		return this.dispatcher;
+	public CommandRegistrationStrategy<CLW> createCommandRegistrationStrategy() {
+		return new SpigotCommandRegistration<>(this, dispatcher, resourcesDispatcher);
 	}
 
-	@Override
 	public CommandDispatcher<CLW> getResourcesDispatcher() {
-		if (this.resourcesDispatcher == null) {
-			this.resourcesDispatcher = new CommandDispatcher<>();
-		}
-		return this.resourcesDispatcher;
+		return resourcesDispatcher;
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/src/main/java/dev/jorel/commandapi/test/MockPlatform.java
@@ -71,7 +71,7 @@ public abstract class MockPlatform<CLW> extends CommandAPIBukkit<CLW> {
 
 	@Override
 	public CommandRegistrationStrategy<CLW> createCommandRegistrationStrategy() {
-		return new SpigotCommandRegistration<>(this, dispatcher, resourcesDispatcher);
+		return new SpigotCommandRegistration<>(this, dispatcher, () -> resourcesDispatcher);
 	}
 
 	public CommandDispatcher<CLW> getResourcesDispatcher() {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/CommandNamespaceTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/CommandNamespaceTests.java
@@ -3,11 +3,7 @@ package dev.jorel.commandapi.test;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIBukkitConfig;
-import dev.jorel.commandapi.CommandAPICommand;
-import dev.jorel.commandapi.CommandTree;
-import dev.jorel.commandapi.InternalBukkitConfig;
+import dev.jorel.commandapi.*;
 import dev.jorel.commandapi.arguments.IntegerArgument;
 import dev.jorel.commandapi.arguments.LiteralArgument;
 import dev.jorel.commandapi.arguments.StringArgument;
@@ -53,8 +49,9 @@ public class CommandNamespaceTests extends TestBase {
 		// Simulate `CraftServer#setVanillaCommands`
 		MockPlatform<Object> mockPlatform = MockPlatform.getInstance();
 		SimpleCommandMap commandMap = mockPlatform.getSimpleCommandMap();
+		SpigotCommandRegistration<Object> spigotCommandRegistration = (SpigotCommandRegistration<Object>) mockPlatform.getCommandRegistrationStrategy();
 		for (CommandNode<Object> node : mockPlatform.getBrigadierDispatcher().getRoot().getChildren()) {
-			commandMap.register("minecraft", mockPlatform.wrapToVanillaCommandWrapper(node));
+			commandMap.register("minecraft", spigotCommandRegistration.wrapToVanillaCommandWrapper(node));
 		}
 
 		// Run the CommandAPI's enable tasks, especially `fixNamespaces`

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.tree.RootCommandNode;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPIBukkit;
 import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.SpigotCommandRegistration;
 import dev.jorel.commandapi.arguments.StringArgument;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -123,20 +124,21 @@ class OnEnableTests extends TestBase {
 			  }
 			}""", getDispatcherString());
 
-		// Make sure command and its aliases exist in the Bukkit CommandMap as VanillaCommandWrappers
+		// Make sure command and its aliases exist in the Bukkit CommandMap
 		SimpleCommandMap commandMap = CommandAPIBukkit.get().getSimpleCommandMap();
+		SpigotCommandRegistration<?> spigotCommandRegistration = (SpigotCommandRegistration<?>) CommandAPIBukkit.get().getCommandRegistrationStrategy();
 
 		Command mainCommand = commandMap.getCommand("command");
 		assertNotNull(mainCommand);
-		assertTrue(CommandAPIBukkit.get().isVanillaCommandWrapper(mainCommand));
+		assertTrue(spigotCommandRegistration.isVanillaCommandWrapper(mainCommand));
 
 		Command alias1Command = commandMap.getCommand("alias1");
 		assertNotNull(alias1Command);
-		assertTrue(CommandAPIBukkit.get().isVanillaCommandWrapper(alias1Command));
+		assertTrue(spigotCommandRegistration.isVanillaCommandWrapper(alias1Command));
 
 		Command alias2Command = commandMap.getCommand("alias2");
 		assertNotNull(alias2Command);
-		assertTrue(CommandAPIBukkit.get().isVanillaCommandWrapper(alias2Command));
+		assertTrue(spigotCommandRegistration.isVanillaCommandWrapper(alias2Command));
 
 		// Make sure namespaces were set up as well
 		assertEquals(mainCommand, commandMap.getCommand("minecraft:command"));
@@ -150,7 +152,7 @@ class OnEnableTests extends TestBase {
 
 
 		// Make sure commands were added to 'resources' dispatcher
-		RootCommandNode<?> resourcesRoot = MockPlatform.getInstance().getResourcesDispatcher().getRoot();
+		RootCommandNode<?> resourcesRoot = MockPlatform.getInstance().getMockResourcesDispatcher().getRoot();
 
 		assertNotNull(resourcesRoot.getChild("command"));
 		assertNotNull(resourcesRoot.getChild("alias1"));

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/OnEnableTests.java
@@ -150,7 +150,7 @@ class OnEnableTests extends TestBase {
 
 
 		// Make sure commands were added to 'resources' dispatcher
-		RootCommandNode<?> resourcesRoot = CommandAPIBukkit.get().getResourcesDispatcher().getRoot();
+		RootCommandNode<?> resourcesRoot = MockPlatform.getInstance().getResourcesDispatcher().getRoot();
 
 		assertNotNull(resourcesRoot.getChild("command"));
 		assertNotNull(resourcesRoot.getChild("alias1"));


### PR DESCRIPTION
This PR moves a lot of the current logic for registering commands on Bukkit into the class `SpigotCommandRegistration`. This allows an alternate implementation of the new `CommandRegistrationStrategy` interface to be loaded when internal changes from https://github.com/PaperMC/Paper/pull/8235 (Paper-1.20.6-65 and later) are present. The `CommandRegistrationStrategy` is created by the method `NMS#createCommandRegistrationStrategy`.

This is a more permanent fix than https://github.com/JorelAli/CommandAPI/pull/555 and resolves these issues when running on Paper-1.20.65 and later:
- Running `/minecraft:reload` deletes CommandAPI commands (Thanks FireML on [Discord](https://discord.com/channels/745416925924032523/745757702608912556/1245385777056190534))
- `unregisterBukkit` parameter of `CommandAPIBukkit#unregister` isn't fully taken into account

The implementation can still probably be refined by https://github.com/JorelAli/CommandAPI/pull/517 (e.g. CommandAPI-Spigot should never need `PaperCommandRegistration`, and later Paper versions should never need `SpigotCommandReigistration`)

The NMS methods `getResourcesDispatcher`, `isVanillaCommandWrapper`, `wrapToVanillaCommandWrapper`, and `isBukkitCommandWrapper` were moved to `SpigotCommandRegistration` because they only make sense if Paper changes are not present. These methods are only used in the CommandAPI by `SpigotCommandRegistration` anyway, but developers can still access them using `CommandAPIBukkit#getCommandRegistrationStrategy`. `PaperCommandRegistration` provides a similar method: `isBukkitCommand`.

### TODO:

Before merging I want to double check that the following works

- Commands register during server start up
- Commands register after server enables
- `unregisterBukkit` parameter is repsected
- Commands persist after `minecraft:reload`

On the following versions:

- [x] Latest Paper (Paper-1.20.6-131)
- [x] Paper-1.20.6-65
- [x] Paper-1.20.6-64
- [x] Paper-1.20.5
- [x] Paper-1.20.4

- [x] Spigot 1.20.6
- [x] Spigot 1.20.4

And of course~ code review is greatly appreciated!