### PR TITLE
Link latest.html to 9.4.1 documentation

### DIFF
--- a/docs/latest.html
+++ b/docs/latest.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-    <meta http-equiv="refresh" content="0; URL='./9.4.2/index.html" />
+    <meta http-equiv="refresh" content="0; URL='./9.4.1/index.html" />
     <style>
         body {
             margin: 0;
@@ -47,7 +47,7 @@
 <body>
     <div id="sidebar"></div>
     <div id="main">
-        <p>Loading the CommandAPI documentation...<br><span>(Didn't load? Try <a href="./9.4.2/index.html">this link here!</a>)</span></p>
+        <p>Loading the CommandAPI documentation...<br><span>(Didn't load? Try <a href="./9.4.1/index.html">this link here!</a>)</span></p>
     </div>
 </body>
 


### PR DESCRIPTION
Currently, the CommandAPI home page says that 9.4.1 is the latest documentation. However, the button actually links to `latest.html`, which forwards to the 9.4.2 documentation (https://commandapi.jorel.dev/9.4.2/index.html). This page doesn't actually exist, so you get a 404 not found.

When the `update.sh` script was run to change the version from `9.5.0-SNAPSHOT` to `9.4.2`, it incorrectly updated `latest.html` to point to `9.4.2`, even though 9.4.2 didn't have any documentation updates.

This PR makes it so `latest.html` correctly goes to the 9.4.1 documentation (https://commandapi.jorel.dev/9.4.1/index.html).