### PR TITLE
Modify gradle shadow plugin to use Goooler's fork for Java 21 support (Issue #567)

### DIFF
--- a/docssrc/src/setup_shading.md
+++ b/docssrc/src/setup_shading.md
@@ -176,21 +176,21 @@ As we're shading the CommandAPI into your plugin, you **don't** need to add `dep
 
 ## Shading with Gradle
 
-To shade the CommandAPI into a Gradle project, we'll use the [Gradle Shadow Plugin](https://imperceptiblethoughts.com/shadow/). Add this to your list of plugins:
+To shade the CommandAPI into a Gradle project, we'll use the [Goooler Gradle Shadow Plugin](https://plugins.gradle.org/plugin/io.github.goooler.shadow). This is a fork of the [Shadow Plugin](https://imperceptiblethoughts.com/shadow/) which supports Java 21. Add this to your list of plugins:
 
 <div class="multi-pre">
 
 ```groovy,build.gradle
 plugins {
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'io.github.goooler.shadow' version '8.1.7'
 }
 ```
 
 ```kotlin,build.gradle.kts
 plugins {
     java
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("io.github.goooler.shadow") version "8.1.7"
 }
 ```
 


### PR DESCRIPTION
Makes the documentation be specific about using Goooler's fork of the gradle shadow plugin, as it broke with Java 21.