### PR TITLE
Be more lenient with version checks when updating the minor version of the game

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ This is the current roadmap for the CommandAPI (as of 30th April 2024):
             <td valign="top">???</td>
             <td valign="top">
                 <ul>
-                    <li>https://github.com/JorelAli/CommandAPI/pull/594 Adds a config option to allow the CommandAPI to be more lenient when updating to a new minor version (e. g. from 1.21 to 1.21.1)</li>
+                    <li>https://github.com/JorelAli/CommandAPI/pull/594 Adds a config option to allow the CommandAPI to be more lenient when updating to a new minor version (e.g. from 1.21 to 1.21.1)</li>
                 </ul>
             </td>
         </tr>

--- a/README.md
+++ b/README.md
@@ -410,6 +410,15 @@ This is the current roadmap for the CommandAPI (as of 30th April 2024):
     </thead>
     <tbody>
         <tr>
+            <td valign="top"><b>9.6.0</b></td>
+            <td valign="top">???</td>
+            <td valign="top">
+                <ul>
+                    <li>https://github.com/JorelAli/CommandAPI/pull/594 Adds a config option to allow the CommandAPI to be more lenient when updating to a new minor version (e. g. from 1.21 to 1.21.1)</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
             <td valign="top"><b>9.5.3</b></td>
             <td valign="top">August 2024</td>
             <td valign="top">

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
@@ -112,6 +112,11 @@ public class CommandAPI {
 			CommandAPIPlatform<?, ?, ?> platform = CommandAPIVersionHandler.getPlatform();
 			new CommandAPIHandler<>(platform);
 
+			if (CommandAPI.getConfiguration().shouldUseLatestNMSVersion() || CommandAPI.getConfiguration().shouldBeLenientForMinorVersions()) {
+				CommandAPI.logWarning("Loading the CommandAPI with a potentially incompatible NMS implementation.");
+				CommandAPI.logWarning("While you may find success with this, further updates might be necessary to fully support the version you are using.");
+			}
+
 			// Log platform load
 			final String platformClassHierarchy;
 			{

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
@@ -109,13 +109,10 @@ public class CommandAPI {
 			CommandAPI.config = new InternalConfig(config);
 
 			// Initialize handlers
-			CommandAPIPlatform<?, ?, ?> platform = CommandAPIVersionHandler.getPlatform();
+			LoadContext loadContext = CommandAPIVersionHandler.getPlatform();
+			CommandAPIPlatform<?, ?, ?> platform = loadContext.platform();
 			new CommandAPIHandler<>(platform);
-
-			if (CommandAPI.getConfiguration().shouldUseLatestNMSVersion() || CommandAPI.getConfiguration().shouldBeLenientForMinorVersions()) {
-				CommandAPI.logWarning("Loading the CommandAPI with a potentially incompatible NMS implementation.");
-				CommandAPI.logWarning("While you may find success with this, further updates might be necessary to fully support the version you are using.");
-			}
+			loadContext.context().run();
 
 			// Log platform load
 			final String platformClassHierarchy;

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
@@ -39,7 +39,7 @@ extends CommandAPIConfig<Impl>
 	boolean verboseOutput = false;
 	boolean silentLogs = false;
 	boolean useLatestNMSVersion = false;
-	boolean lenientForMinorVersions = false;
+	boolean beLenientForMinorVersions = false;
 	String missingExecutorImplementationMessage = "This command has no implementations for %s";
 
 	File dispatcherFile = null;
@@ -93,7 +93,7 @@ extends CommandAPIConfig<Impl>
 
 	/**
 	 * Sets whether the CommandAPI should load a (potentially unsupported) NMS version
-	 * when updating to a minor release of Minecraft, for example this setting would
+	 * when updating to a minor release of Minecraft. For example, this setting would
 	 * allow running a minor version of the game before the CommandAPI makes a proper
 	 * release for it. Unlike {@link #useLatestNMSVersion(boolean)}, this setting does
 	 * not blindly load the latest NMS version and as a result break cross version compatibility
@@ -102,8 +102,8 @@ extends CommandAPIConfig<Impl>
 	 * @param value whether the CommandAPI should assume that minor Minecraft releases do not cause incompatibilities
 	 * @return this CommandAPIConfig
 	 */
-	public Impl lenientForMinorVersions(boolean value) {
-		this.lenientForMinorVersions = value;
+	public Impl beLenientForMinorVersions(boolean value) {
+		this.beLenientForMinorVersions = value;
 		return instance();
 	}
 

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
@@ -96,8 +96,7 @@ extends CommandAPIConfig<Impl>
 	 * when updating to a minor release of Minecraft. As an example, this setting can allow
 	 * updating to 1.21.2 from 1.21.1 but doesn't allow updating to 1.22 from 1.21.2.
 	 * Unlike {@link #useLatestNMSVersion(boolean)}, this setting does
-	 * not blindly load the latest NMS version and as a result breaks cross version compatibility
-	 * but will actually prefer loading the correct NMS implementation.
+	 * not blindly load the latest NMS version, but will prefer loading the correct NMS implementation when available.
 	 *
 	 * @param value whether the CommandAPI should assume that minor Minecraft releases do not cause incompatibilities
 	 * @return this CommandAPIConfig

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
@@ -39,6 +39,7 @@ extends CommandAPIConfig<Impl>
 	boolean verboseOutput = false;
 	boolean silentLogs = false;
 	boolean useLatestNMSVersion = false;
+	boolean lenientForMinorVersions = false;
 	String missingExecutorImplementationMessage = "This command has no implementations for %s";
 
 	File dispatcherFile = null;
@@ -87,6 +88,22 @@ extends CommandAPIConfig<Impl>
 	 */
 	public Impl useLatestNMSVersion(boolean value) {
 		this.useLatestNMSVersion = value;
+		return instance();
+	}
+
+	/**
+	 * Sets whether the CommandAPI should load a (potentially unsupported) NMS version
+	 * when updating to a minor release of Minecraft, for example this setting would
+	 * allow running a minor version of the game before the CommandAPI makes a proper
+	 * release for it. Unlike {@link #useLatestNMSVersion(boolean)}, this setting does
+	 * not blindly load the latest NMS version and as a result break cross version compatibility
+	 * but will actually prefer loading the correct NMS implementation.
+	 *
+	 * @param value whether the CommandAPI should assume that minor Minecraft releases do not cause incompatibilities
+	 * @return this CommandAPIConfig
+	 */
+	public Impl lenientForMinorVersions(boolean value) {
+		this.lenientForMinorVersions = value;
 		return instance();
 	}
 

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
@@ -93,10 +93,10 @@ extends CommandAPIConfig<Impl>
 
 	/**
 	 * Sets whether the CommandAPI should load a (potentially unsupported) NMS version
-	 * when updating to a minor release of Minecraft. For example, this setting would
-	 * allow running a minor version of the game before the CommandAPI makes a proper
-	 * release for it. Unlike {@link #useLatestNMSVersion(boolean)}, this setting does
-	 * not blindly load the latest NMS version and as a result break cross version compatibility
+	 * when updating to a minor release of Minecraft. As an example, this setting can allow
+	 * updating to 1.21.2 from 1.21.1 but doesn't allow updating to 1.22 from 1.21.2.
+	 * Unlike {@link #useLatestNMSVersion(boolean)}, this setting does
+	 * not blindly load the latest NMS version and as a result breaks cross version compatibility
 	 * but will actually prefer loading the correct NMS implementation.
 	 *
 	 * @param value whether the CommandAPI should assume that minor Minecraft releases do not cause incompatibilities

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
@@ -12,7 +12,7 @@ public interface CommandAPIVersionHandler {
 	 *
 	 * @return an instance of CommandAPIPlatform which can run on the currently active server
 	 */
-	static CommandAPIPlatform<?, ?, ?> getPlatform() {
+	static LoadContext getPlatform() {
 		throw new IllegalStateException("You have the wrong copy of the CommandAPI! If you're shading, did you use commandapi-core instead of commandapi-{platform}-shade?");
 	}
 }

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/InternalConfig.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/InternalConfig.java
@@ -40,7 +40,7 @@ public class InternalConfig {
 	// Whether we should use the latest NMS version (which may not be compatible)
 	private final boolean useLatestNMSVersion;
 
-	private final boolean beMoreLenientForMinorVerions;
+	private final boolean beLenientForMinorVersions;
 
 	// The message to display when an executor implementation is missing
 	private final String messageMissingExecutorImplementation;
@@ -67,7 +67,7 @@ public class InternalConfig {
 		this.verboseOutput = config.verboseOutput;
 		this.silentLogs = config.silentLogs;
 		this.useLatestNMSVersion = config.useLatestNMSVersion;
-		this.beMoreLenientForMinorVerions = config.lenientForMinorVersions;
+		this.beLenientForMinorVersions = config.beLenientForMinorVersions;
 		this.messageMissingExecutorImplementation = config.missingExecutorImplementationMessage;
 		this.dispatcherFile = config.dispatcherFile;
 		this.skipSenderProxy = config.skipSenderProxy;
@@ -100,8 +100,8 @@ public class InternalConfig {
 	/**
 	 * @return Whether the CommandAPI should assume that minor versions of officially unsupported versions do not cause incompatibilities
 	 */
-	public boolean shouldBeMoreLenientForMinorVersions() {
-		return this.beMoreLenientForMinorVerions;
+	public boolean shouldBeLenientForMinorVersions() {
+		return this.beLenientForMinorVersions;
 	}
 
 	/**

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/InternalConfig.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/InternalConfig.java
@@ -40,6 +40,8 @@ public class InternalConfig {
 	// Whether we should use the latest NMS version (which may not be compatible)
 	private final boolean useLatestNMSVersion;
 
+	private final boolean beMoreLenientForMinorVerions;
+
 	// The message to display when an executor implementation is missing
 	private final String messageMissingExecutorImplementation;
 
@@ -65,6 +67,7 @@ public class InternalConfig {
 		this.verboseOutput = config.verboseOutput;
 		this.silentLogs = config.silentLogs;
 		this.useLatestNMSVersion = config.useLatestNMSVersion;
+		this.beMoreLenientForMinorVerions = config.lenientForMinorVersions;
 		this.messageMissingExecutorImplementation = config.missingExecutorImplementationMessage;
 		this.dispatcherFile = config.dispatcherFile;
 		this.skipSenderProxy = config.skipSenderProxy;
@@ -92,6 +95,13 @@ public class InternalConfig {
 	 */
 	public boolean shouldUseLatestNMSVersion() {
 		return this.useLatestNMSVersion;
+	}
+
+	/**
+	 * @return Whether the CommandAPI should assume that minor versions of officially unsupported versions do not cause incompatibilities
+	 */
+	public boolean shouldBeMoreLenientForMinorVersions() {
+		return this.beMoreLenientForMinorVerions;
 	}
 
 	/**

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/LoadContext.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/LoadContext.java
@@ -1,4 +1,9 @@
 package dev.jorel.commandapi;
 
 public record LoadContext(CommandAPIPlatform<?, ?, ?> platform, Runnable context) {
+
+	public LoadContext(CommandAPIPlatform<?, ?, ?> platform) {
+		this(platform, () -> {});
+	}
+
 }

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/LoadContext.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/LoadContext.java
@@ -1,0 +1,4 @@
+package dev.jorel.commandapi;
+
+public record LoadContext(CommandAPIPlatform<?, ?, ?> platform, Runnable context) {
+}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -51,7 +51,8 @@ public class CommandAPIMain extends JavaPlugin {
 			.missingExecutorImplementationMessage(fileConfig.getString("messages.missing-executor-implementation"))
 			.dispatcherFile(fileConfig.getBoolean("create-dispatcher-json") ? new File(getDataFolder(), "command_registration.json") : null)
 			.shouldHookPaperReload(fileConfig.getBoolean("hook-paper-reload"))
-			.skipReloadDatapacks(fileConfig.getBoolean("skip-initial-datapack-reload"));
+			.skipReloadDatapacks(fileConfig.getBoolean("skip-initial-datapack-reload"))
+			.lenientForMinorVersions(fileConfig.getBoolean("lenient-for-minor-versions"));
 
 		for (String pluginName : fileConfig.getStringList("skip-sender-proxy")) {
 			if (Bukkit.getPluginManager().getPlugin(pluginName) != null) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -52,7 +52,7 @@ public class CommandAPIMain extends JavaPlugin {
 			.dispatcherFile(fileConfig.getBoolean("create-dispatcher-json") ? new File(getDataFolder(), "command_registration.json") : null)
 			.shouldHookPaperReload(fileConfig.getBoolean("hook-paper-reload"))
 			.skipReloadDatapacks(fileConfig.getBoolean("skip-initial-datapack-reload"))
-			.beLenientForMinorVersions(fileConfig.getBoolean("lenient-for-minor-versions"));
+			.beLenientForMinorVersions(fileConfig.getBoolean("be-lenient-for-minor-versions"));
 
 		for (String pluginName : fileConfig.getStringList("skip-sender-proxy")) {
 			if (Bukkit.getPluginManager().getPlugin(pluginName) != null) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -52,7 +52,7 @@ public class CommandAPIMain extends JavaPlugin {
 			.dispatcherFile(fileConfig.getBoolean("create-dispatcher-json") ? new File(getDataFolder(), "command_registration.json") : null)
 			.shouldHookPaperReload(fileConfig.getBoolean("hook-paper-reload"))
 			.skipReloadDatapacks(fileConfig.getBoolean("skip-initial-datapack-reload"))
-			.lenientForMinorVersions(fileConfig.getBoolean("lenient-for-minor-versions"));
+			.beLenientForMinorVersions(fileConfig.getBoolean("lenient-for-minor-versions"));
 
 		for (String pluginName : fileConfig.getStringList("skip-sender-proxy")) {
 			if (Bukkit.getPluginManager().getPlugin(pluginName) != null) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/resources/config.yml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/resources/config.yml
@@ -46,7 +46,7 @@ use-latest-nms-version: false
 # For example, this setting may allow updating from 1.21.1 to 1.21.2 as only the minor version is changing
 # but will not allow an update from 1.21.2 to 1.22.
 # Keep in mind that implementations may vary and actually updating the CommandAPI might be necessary.
-lenient-for-minor-versions: false
+be-lenient-for-minor-versions: false
 
 # Hook into Paper's ServerResourcesReloadedEvent (default: true)
 # If "true", and the CommandAPI detects it is running on a Paper server, it will

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/resources/config.yml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/resources/config.yml
@@ -44,8 +44,8 @@ use-latest-nms-version: false
 # Be lenient with version checks when loading for new minor Minecraft versions (default: false)
 # If "true", the CommandAPI loads NMS implementations for (potentially unsupported) Minecraft versions.
 # For example, this setting may allow updating from 1.21.1 to 1.21.2 as only the minor version is changing
-# but will not allow an update from 1.21.2 to 1.22
-# Keep in mind that implementations my vary and actually updating the CommandAPI might be necessary.
+# but will not allow an update from 1.21.2 to 1.22.
+# Keep in mind that implementations may vary and actually updating the CommandAPI might be necessary.
 lenient-for-minor-versions: false
 
 # Hook into Paper's ServerResourcesReloadedEvent (default: true)

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/resources/config.yml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/resources/config.yml
@@ -41,6 +41,13 @@ create-dispatcher-json: false
 # implementation is actually compatible with the current Minecraft version.
 use-latest-nms-version: false
 
+# Be lenient with version checks when loading for new minor Minecraft versions (default: false)
+# If "true", the CommandAPI loads NMS implementations for (potentially unsupported) Minecraft versions.
+# For example, this setting may allow updating from 1.21.1 to 1.21.2 as only the minor version is changing
+# but will not allow an update from 1.21.2 to 1.22
+# Keep in mind that implementations my vary and actually updating the CommandAPI might be necessary.
+lenient-for-minor-versions: false
+
 # Hook into Paper's ServerResourcesReloadedEvent (default: true)
 # If "true", and the CommandAPI detects it is running on a Paper server, it will
 # hook into Paper's ServerResourcesReloadedEvent to detect when /minecraft:reload is run.

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -51,7 +51,8 @@ public class CommandAPIMain extends JavaPlugin {
 			.missingExecutorImplementationMessage(fileConfig.getString("messages.missing-executor-implementation"))
 			.dispatcherFile(fileConfig.getBoolean("create-dispatcher-json") ? new File(getDataFolder(), "command_registration.json") : null)
 			.shouldHookPaperReload(fileConfig.getBoolean("hook-paper-reload"))
-			.skipReloadDatapacks(fileConfig.getBoolean("skip-initial-datapack-reload"));
+			.skipReloadDatapacks(fileConfig.getBoolean("skip-initial-datapack-reload"))
+			.lenientForMinorVersions(fileConfig.getBoolean("lenient-for-minor-versions"));
 
 		for (String pluginName : fileConfig.getStringList("skip-sender-proxy")) {
 			if (Bukkit.getPluginManager().getPlugin(pluginName) != null) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -52,7 +52,7 @@ public class CommandAPIMain extends JavaPlugin {
 			.dispatcherFile(fileConfig.getBoolean("create-dispatcher-json") ? new File(getDataFolder(), "command_registration.json") : null)
 			.shouldHookPaperReload(fileConfig.getBoolean("hook-paper-reload"))
 			.skipReloadDatapacks(fileConfig.getBoolean("skip-initial-datapack-reload"))
-			.beLenientForMinorVersions(fileConfig.getBoolean("lenient-for-minor-versions"));
+			.beLenientForMinorVersions(fileConfig.getBoolean("be-lenient-for-minor-versions"));
 
 		for (String pluginName : fileConfig.getStringList("skip-sender-proxy")) {
 			if (Bukkit.getPluginManager().getPlugin(pluginName) != null) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -52,7 +52,7 @@ public class CommandAPIMain extends JavaPlugin {
 			.dispatcherFile(fileConfig.getBoolean("create-dispatcher-json") ? new File(getDataFolder(), "command_registration.json") : null)
 			.shouldHookPaperReload(fileConfig.getBoolean("hook-paper-reload"))
 			.skipReloadDatapacks(fileConfig.getBoolean("skip-initial-datapack-reload"))
-			.lenientForMinorVersions(fileConfig.getBoolean("lenient-for-minor-versions"));
+			.beLenientForMinorVersions(fileConfig.getBoolean("lenient-for-minor-versions"));
 
 		for (String pluginName : fileConfig.getStringList("skip-sender-proxy")) {
 			if (Bukkit.getPluginManager().getPlugin(pluginName) != null) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/resources/config.yml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/resources/config.yml
@@ -46,7 +46,7 @@ use-latest-nms-version: false
 # For example, this setting may allow updating from 1.21.1 to 1.21.2 as only the minor version is changing
 # but will not allow an update from 1.21.2 to 1.22.
 # Keep in mind that implementations may vary and actually updating the CommandAPI might be necessary.
-lenient-for-minor-versions: false
+be-lenient-for-minor-versions: false
 
 # Hook into Paper's ServerResourcesReloadedEvent (default: true)
 # If "true", and the CommandAPI detects it is running on a Paper server, it will

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/resources/config.yml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/resources/config.yml
@@ -44,8 +44,8 @@ use-latest-nms-version: false
 # Be lenient with version checks when loading for new minor Minecraft versions (default: false)
 # If "true", the CommandAPI loads NMS implementations for (potentially unsupported) Minecraft versions.
 # For example, this setting may allow updating from 1.21.1 to 1.21.2 as only the minor version is changing
-# but will not allow an update from 1.21.2 to 1.22
-# Keep in mind that implementations my vary and actually updating the CommandAPI might be necessary.
+# but will not allow an update from 1.21.2 to 1.22.
+# Keep in mind that implementations may vary and actually updating the CommandAPI might be necessary.
 lenient-for-minor-versions: false
 
 # Hook into Paper's ServerResourcesReloadedEvent (default: true)

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/resources/config.yml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/resources/config.yml
@@ -41,6 +41,13 @@ create-dispatcher-json: false
 # implementation is actually compatible with the current Minecraft version.
 use-latest-nms-version: false
 
+# Be lenient with version checks when loading for new minor Minecraft versions (default: false)
+# If "true", the CommandAPI loads NMS implementations for (potentially unsupported) Minecraft versions.
+# For example, this setting may allow updating from 1.21.1 to 1.21.2 as only the minor version is changing
+# but will not allow an update from 1.21.2 to 1.22
+# Keep in mind that implementations my vary and actually updating the CommandAPI might be necessary.
+lenient-for-minor-versions: false
+
 # Hook into Paper's ServerResourcesReloadedEvent (default: true)
 # If "true", and the CommandAPI detects it is running on a Paper server, it will
 # hook into Paper's ServerResourcesReloadedEvent to detect when /minecraft:reload is run.

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-kotlin-test/src/test/kotlin/dev/jorel/commandapi/CommandAPIVersionHandler.kt
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-kotlin-test/src/test/kotlin/dev/jorel/commandapi/CommandAPIVersionHandler.kt
@@ -13,8 +13,8 @@ interface CommandAPIVersionHandler {
 	companion object {
 
 		@JvmStatic
-		fun getPlatform() : CommandAPIPlatform<*, *, *> {
-			return MockNMS(NMS_1_19_1_R1());
+		fun getPlatform() : LoadContext {
+			return LoadContext(MockNMS(NMS_1_19_1_R1())) {}
 		}
 
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-kotlin-test/src/test/kotlin/dev/jorel/commandapi/CommandAPIVersionHandler.kt
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-kotlin-test/src/test/kotlin/dev/jorel/commandapi/CommandAPIVersionHandler.kt
@@ -14,7 +14,7 @@ interface CommandAPIVersionHandler {
 
 		@JvmStatic
 		fun getPlatform() : LoadContext {
-			return LoadContext(MockNMS(NMS_1_19_1_R1())) {}
+			return LoadContext(MockNMS(NMS_1_19_1_R1()))
 		}
 
 	}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
@@ -59,7 +59,7 @@ public interface CommandAPIVersionHandler {
 				case "Minecraft_1_17" -> new NMS_1_17();
 				case "Minecraft_1_16_5" -> new NMS_1_16_R3();
 				default -> throw new IllegalArgumentException("Unexpected value: " + System.getProperty("profileId"));
-			}), () -> {});
+			}));
 		}
 	}
 	

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
@@ -43,12 +43,12 @@ public interface CommandAPIVersionHandler {
 		}
 	}
 	
-	static CommandAPIPlatform<?, ?, ?> getPlatform() {
+	static LoadContext getPlatform() {
 		if(profileId == null) {
 			System.out.println("Using default version 1.19.4");
-			return new MockNMS(new NMS_1_19_4_R3());
+			return new LoadContext(new MockNMS(new NMS_1_19_4_R3()), () -> {});
 		} else {
-			return new MockNMS(switch(profileId) {
+			return new LoadContext(new MockNMS(switch(profileId) {
 				case "Minecraft_1_20_5" -> new NMS_1_20_R4();
 				case "Minecraft_1_20_3" -> new NMS_1_20_R3();
 				case "Minecraft_1_20_2" -> new NMS_1_20_R2();
@@ -59,7 +59,7 @@ public interface CommandAPIVersionHandler {
 				case "Minecraft_1_17" -> new NMS_1_17();
 				case "Minecraft_1_16_5" -> new NMS_1_16_R3();
 				default -> throw new IllegalArgumentException("Unexpected value: " + System.getProperty("profileId"));
-			});
+			}), () -> {});
 		}
 	}
 	

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
@@ -46,7 +46,7 @@ public interface CommandAPIVersionHandler {
 	static LoadContext getPlatform() {
 		if(profileId == null) {
 			System.out.println("Using default version 1.19.4");
-			return new LoadContext(new MockNMS(new NMS_1_19_4_R3()), () -> {});
+			return new LoadContext(new MockNMS(new NMS_1_19_4_R3()));
 		} else {
 			return new LoadContext(new MockNMS(switch(profileId) {
 				case "Minecraft_1_20_5" -> new NMS_1_20_R4();

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-vh/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-vh/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
@@ -24,6 +24,8 @@ import dev.jorel.commandapi.exceptions.UnsupportedVersionException;
 import dev.jorel.commandapi.nms.*;
 import org.bukkit.Bukkit;
 
+import java.util.function.Supplier;
+
 /**
  * This file handles the NMS version to be loaded. The CommandAPIVersionHandler
  * file within the commandapi-core module is NOT used at compile time. Instead,
@@ -49,10 +51,11 @@ public interface CommandAPIVersionHandler {
 	 * @return an instance of NMS which can run on the specified Minecraft version
 	 */
 	static LoadContext getPlatform() {
-		int latestMajorVersion = 21; // Change this for Minecraft's major update
+		String latestMajorVersion = "21"; // Change this for Minecraft's major update
+		Supplier<CommandAPIPlatform<?, ?, ?>> latestNMS = NMS_1_21_R1::new;
 		if (CommandAPI.getConfiguration().shouldUseLatestNMSVersion()) {
-			return new LoadContext(new NMS_1_21_R1(), () -> {
-				CommandAPI.logWarning("Loading the CommandAPI with a potentially incompatible NMS implementation.");
+			return new LoadContext(latestNMS.get(), () -> {
+				CommandAPI.logWarning("Loading the CommandAPI with the latest and potentially incompatible NMS implementation.");
 				CommandAPI.logWarning("While you may find success with this, further updates might be necessary to fully support the version you are using.");
 			});
 		} else {
@@ -75,17 +78,15 @@ public interface CommandAPIVersionHandler {
 				default -> null;
 			};
 			if (platform != null) {
-				return new LoadContext(platform, () -> {});
+				return new LoadContext(platform);
 			}
 			if (CommandAPI.getConfiguration().shouldBeLenientForMinorVersions()) {
-				int currentMajorVersion = Integer.parseInt(version.split("\\.")[1]);
-				if (latestMajorVersion == currentMajorVersion) {
-					return new LoadContext(new NMS_1_21_R1(), () -> {
+				String currentMajorVersion = version.split("\\.")[1];
+				if (latestMajorVersion.equals(currentMajorVersion)) {
+					return new LoadContext(latestNMS.get(), () -> {
 						CommandAPI.logWarning("Loading the CommandAPI with a potentially incompatible NMS implementation.");
 						CommandAPI.logWarning("While you may find success with this, further updates might be necessary to fully support the version you are using.");
 					});
-				} else {
-					throw new UnsupportedVersionException(version);
 				}
 			}
 			throw new UnsupportedVersionException(version);

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-vh/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-vh/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
@@ -48,13 +48,16 @@ public interface CommandAPIVersionHandler {
 	 *
 	 * @return an instance of NMS which can run on the specified Minecraft version
 	 */
-	static CommandAPIPlatform<?, ?, ?> getPlatform() {
+	static LoadContext getPlatform() {
 		int latestMajorVersion = 21; // Change this for Minecraft's major update
 		if (CommandAPI.getConfiguration().shouldUseLatestNMSVersion()) {
-			return new NMS_1_21_R1();
+			return new LoadContext(new NMS_1_21_R1(), () -> {
+				CommandAPI.logWarning("Loading the CommandAPI with a potentially incompatible NMS implementation.");
+				CommandAPI.logWarning("While you may find success with this, further updates might be necessary to fully support the version you are using.");
+			});
 		} else {
 			String version = Bukkit.getBukkitVersion().split("-")[0];
-			return switch (version) {
+			CommandAPIPlatform<?, ?, ?> platform = switch (version) {
 				case "1.16.5" -> new NMS_1_16_R3();
 				case "1.17" -> new NMS_1_17();
 				case "1.17.1" -> new NMS_1_17_R1();
@@ -69,15 +72,23 @@ public interface CommandAPIVersionHandler {
 				case "1.20.3", "1.20.4" -> new NMS_1_20_R3();
 				case "1.20.5", "1.20.6" -> new NMS_1_20_R4();
 				case "1.21", "1.21.1" -> new NMS_1_21_R1();
-				default -> {
-					int currentMajorVersion = Integer.parseInt(version.split("\\.")[1]);
-					if (CommandAPI.getConfiguration().shouldBeLenientForMinorVersions() && latestMajorVersion == currentMajorVersion) {
-						yield new NMS_1_21_R1();
-					} else {
-						throw new UnsupportedVersionException(version);
-					}
-				}
+				default -> null;
 			};
+			if (platform != null) {
+				return new LoadContext(platform, () -> {});
+			}
+			if (CommandAPI.getConfiguration().shouldBeLenientForMinorVersions()) {
+				int currentMajorVersion = Integer.parseInt(version.split("\\.")[1]);
+				if (latestMajorVersion == currentMajorVersion) {
+					return new LoadContext(new NMS_1_21_R1(), () -> {
+						CommandAPI.logWarning("Loading the CommandAPI with a potentially incompatible NMS implementation.");
+						CommandAPI.logWarning("While you may find success with this, further updates might be necessary to fully support the version you are using.");
+					});
+				} else {
+					throw new UnsupportedVersionException(version);
+				}
+			}
+			throw new UnsupportedVersionException(version);
 		}
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-vh/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-vh/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
@@ -49,13 +49,12 @@ public interface CommandAPIVersionHandler {
 	 * @return an instance of NMS which can run on the specified Minecraft version
 	 */
 	static CommandAPIPlatform<?, ?, ?> getPlatform() {
-		CommandAPIPlatform<?, ?, ?> latestNMS = new NMS_1_21_R1();
+		int latestMajorVersion = 21; // Change this for Minecraft's major update
 		if (CommandAPI.getConfiguration().shouldUseLatestNMSVersion()) {
-			return latestNMS;
+			return new NMS_1_21_R1();
 		} else {
 			String version = Bukkit.getBukkitVersion().split("-")[0];
-			Version minecraftVersion = new Version(version);
-			CommandAPIPlatform<?, ?, ?> platform = switch (version) {
+			return switch (version) {
 				case "1.16.5" -> new NMS_1_16_R3();
 				case "1.17" -> new NMS_1_17();
 				case "1.17.1" -> new NMS_1_17_R1();
@@ -70,54 +69,16 @@ public interface CommandAPIVersionHandler {
 				case "1.20.3", "1.20.4" -> new NMS_1_20_R3();
 				case "1.20.5", "1.20.6" -> new NMS_1_20_R4();
 				case "1.21", "1.21.1" -> new NMS_1_21_R1();
-				default -> null;
+				default -> {
+					int currentMajorVersion = Integer.parseInt(version.split("\\.")[1]);
+					if (CommandAPI.getConfiguration().shouldBeLenientForMinorVersions() && latestMajorVersion == currentMajorVersion) {
+						yield new NMS_1_21_R1();
+					} else {
+						throw new UnsupportedVersionException(version);
+					}
+				}
 			};
-			if (platform != null) {
-				return platform;
-			} else {
-				if (CommandAPI.getConfiguration().shouldBeMoreLenientForMinorVersions()) {
-					return minecraftVersion.matchesPatch((NMS<?>) latestNMS);
-				}
-				throw new UnsupportedVersionException(version);
-			}
 		}
-	}
-
-	class Version {
-
-		private final String version;
-
-		// The minor version is something like 1.x
-		private final int minor;
-
-		private Version(String version) {
-			this.version = version;
-			String[] versionParts = version.split("\\.");
-			minor = Integer.parseInt(versionParts[1]);
-		}
-
-		private CommandAPIPlatform<?, ?, ?> matchesPatch(NMS<?> latestNMS) {
-			if (minor <= 16) {
-				// We absolutely do not support versions older than 1.16.5
-				// As we match 1.16.5 in the getPlatform() method, this if branch means that
-				// the server is on 1.16.4 or older
-				throw new UnsupportedVersionException(version);
-			} else {
-				// Any other Minecraft that is older or exactly the last version we match in getPlatform()
-				// does not appear here. Furthermore, we do not want to be lenient with 1.x versions so we
-				// can simply return the latest NMS version here if its supported Minecraft version's minor version
-				// is the same as the current Minecraft version
-				String[] supportedNMSVersions = latestNMS.compatibleVersions();
-				int minorVersion = Integer.parseInt(supportedNMSVersions[0].split("\\.")[1]); // Index 1 returns the minor version by SemVer's rules
-				if (this.minor == minorVersion) {
-					return (CommandAPIPlatform<?, ?, ?>) latestNMS;
-				}
-			}
-			// If we end up here, that means the server's current minor version in SemVer terms is newer than the
-			// latest minor version of Minecraft in SemVer terms that this method allows. We do not support that.
-			throw new UnsupportedVersionException(version);
-		}
-
 	}
 
 }

--- a/commandapi-platforms/commandapi-bukkit/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/pom.xml
@@ -26,10 +26,11 @@
 
 		<!-- Outputs -->
 		<module>commandapi-bukkit-plugin</module>
-		<module>commandapi-bukkit-test</module>
 		<module>commandapi-bukkit-shade</module>
-		
 		<module>commandapi-bukkit-plugin-mojang-mapped</module>
 		<module>commandapi-bukkit-shade-mojang-mapped</module>
+
+		<!-- Tests -->
+		<module>commandapi-bukkit-test</module>
 	</modules>
 </project>

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
@@ -1,7 +1,7 @@
 package dev.jorel.commandapi;
 
 public interface CommandAPIVersionHandler {
-	static CommandAPIPlatform<?, ?, ?> getPlatform() {
-		return new CommandAPIVelocity();
+	static LoadContext getPlatform() {
+		return new LoadContext(new CommandAPIVelocity(), () -> {});
 	}
 }

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVersionHandler.java
@@ -2,6 +2,6 @@ package dev.jorel.commandapi;
 
 public interface CommandAPIVersionHandler {
 	static LoadContext getPlatform() {
-		return new LoadContext(new CommandAPIVelocity(), () -> {});
+		return new LoadContext(new CommandAPIVelocity());
 	}
 }

--- a/docssrc/src/config.md
+++ b/docssrc/src/config.md
@@ -120,7 +120,7 @@ use-latest-nms-version: true
 
 -----
 
-### `lenient-for-minor-versions`
+### `be-lenient-for-minor-versions`
 
 Controls whether the CommandAPI should be more lenient when updating to a new Minecraft version.
 
@@ -135,13 +135,13 @@ Take the warning from the [`use-latest-nms-version`](#use-latest-nms-version) an
 **Default value**
 
 ```yml
-lenient-for-minor-versions: false
+be-lenient-for-minor-versions: false
 ```
 
 **Example value**
 
 ```yml
-lenient-for-minor-versions: true
+be-lenient-for-minor-versions: true
 ```
 
 -----

--- a/docssrc/src/config.md
+++ b/docssrc/src/config.md
@@ -132,6 +132,18 @@ Take the warning from the [`use-latest-nms-version`](#use-latest-nms-version) an
 
 </div>
 
+**Default value**
+
+```yml
+lenient-for-minor-versions: false
+```
+
+**Example value**
+
+```yml
+lenient-for-minor-versions: true
+```
+
 -----
 
 ### `hook-paper-reload`

--- a/docssrc/src/config.md
+++ b/docssrc/src/config.md
@@ -120,6 +120,20 @@ use-latest-nms-version: true
 
 -----
 
+### `lenient-for-minor-versions`
+
+Controls whether the CommandAPI should be more lenient when updating to a new Minecraft version.
+
+Similar to the [`use-latest-nms-version`](#use-latest-nms-version) setting, this can allow the CommandAPI to run on a version higher than it officially supports. As an example, this setting can allow updating to 1.21.2 from 1.21.1 but doesn't allow updating to 1.22 from 1.21.2.
+
+<div class="warning">
+
+Take the warning from the [`use-latest-nms-version`](#use-latest-nms-version) and apply it here too. This is _not_ guaranteed to work either and also may cause unexpected side-effects.
+
+</div>
+
+-----
+
 ### `hook-paper-reload`
 
 Controls whether the CommandAPI hooks into the Paper-exclusive `ServerResourcesReloadedEvent` when available.

--- a/docssrc/src/setup_shading.md
+++ b/docssrc/src/setup_shading.md
@@ -32,7 +32,7 @@ public class CommandAPIConfig {
     CommandAPIConfig verboseOutput(boolean value); // Enables verbose logging
     CommandAPIConfig silentLogs(boolean value);    // Disables ALL logging (except errors)
     CommandAPIConfig useLatestNMSVersion(boolean value); // Whether the latest NMS implementation should be used or not
-    CommandAPIConfig lenientForMinorVersions(boolean value); // Whether the CommandAPI should be more lenient with minor Minecraft versions
+    CommandAPIConfig beLenientForMinorVersions(boolean value); // Whether the CommandAPI should be more lenient with minor Minecraft versions
     CommandAPIConfig missingExecutorImplementationMessage(String value); // Set message to display when executor implementation is missing
     CommandAPIConfig dispatcherFile(File file); // If not null, the CommandAPI will create a JSON file with Brigadier's command tree
     CommandAPIConfig setNamespace(String namespace); // The namespace to use when the CommandAPI registers a command

--- a/docssrc/src/setup_shading.md
+++ b/docssrc/src/setup_shading.md
@@ -32,6 +32,7 @@ public class CommandAPIConfig {
     CommandAPIConfig verboseOutput(boolean value); // Enables verbose logging
     CommandAPIConfig silentLogs(boolean value);    // Disables ALL logging (except errors)
     CommandAPIConfig useLatestNMSVersion(boolean value); // Whether the latest NMS implementation should be used or not
+    CommandAPIConfig lenientForMinorVersions(boolean value); // Whether the CommandAPI should be more lenient with minor Minecraft versions
     CommandAPIConfig missingExecutorImplementationMessage(String value); // Set message to display when executor implementation is missing
     CommandAPIConfig dispatcherFile(File file); // If not null, the CommandAPI will create a JSON file with Brigadier's command tree
     CommandAPIConfig setNamespace(String namespace); // The namespace to use when the CommandAPI registers a command


### PR DESCRIPTION
Currently, when updating to *any* new Minecraft version that is not currently supported, we throw an `UnsupportedVersionException`.
This is not that great since even minor updates require an update to not throw that exception.

This pull request enables, when setting the config option, an update to minor versions of the game:
- An update from 1.21.1 to 1.21.2 would be allowed
- An update from 1.21.2 to 1.22 would still result in an `UnsupportedVersionException` since presumably we still want to double check compatibility for major versions.

**So why the new config option when we have the option of just loading the latest NMS version?**
Well, the latest NMS version completely breaks support for older versions, this only does something when a server version is used that the main part of `CommandAPIVersionHandler#getPlatform()` does not handle currently.

**Further considerations:**
Currently, this does not include a new config option for the plugin version but I think this is something that could and should be done before merging.