### PR TITLE
Implement NestedArguments (#529)

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractArgumentTree.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractArgumentTree.java
@@ -3,6 +3,7 @@ package dev.jorel.commandapi;
 import dev.jorel.commandapi.arguments.AbstractArgument;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -68,19 +69,31 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 	 * @param trees The child branches to add in a chain.
 	 * @return this tree node
 	 */
-	@SafeVarargs
-	public final Impl thenNested(final AbstractArgumentTree<?, Argument, CommandSender>... trees) {
-		int length = trees.length;
+	public final Impl thenNested(List<AbstractArgumentTree<?, Argument, CommandSender>> trees) {
+		int length = trees.size();
 		if (length == 0) {
 			return instance();
 		}
 
-		AbstractArgumentTree<?, Argument, CommandSender> combined = trees[length - 1];
+		AbstractArgumentTree<?, Argument, CommandSender> combined = trees.get(length - 1);
 		for (int i = length - 2; i >= 0; i--) {
-			combined = trees[i].then(combined);
+			combined = trees.get(i).then(combined);
 		}
 
 		return then(combined);
+	}
+
+	/**
+	 * Creates a chain of child branches starting at this node
+	 * <p>
+	 * {@code thenNested(a, b, c)} is equivalent to {@link #then}{@code (a.then(b.then(c)))}.
+	 *
+	 * @param trees The child branches to add in a chain.
+	 * @return this tree node
+	 */
+	@SafeVarargs
+	public final Impl thenNested(final AbstractArgumentTree<?, Argument, CommandSender>... trees) {
+		return thenNested(Arrays.asList(trees));
 	}
 
 	List<Execution<CommandSender, Argument>> getExecutions() {

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractArgumentTree.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractArgumentTree.java
@@ -60,6 +60,21 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 		return instance();
 	}
 
+	@SafeVarargs
+	public final Impl thenNested(final AbstractArgumentTree<?, Argument, CommandSender>... trees) {
+		int length = trees.length;
+		if (length == 0) {
+			return instance();
+		}
+
+		AbstractArgumentTree<?, Argument, CommandSender> combined = trees[length - 1];
+		for (int i = length - 2; i >= 0; i--) {
+			combined = trees[i].then(combined);
+		}
+
+		return then(combined);
+	}
+
 	List<Execution<CommandSender, Argument>> getExecutions() {
 		List<Execution<CommandSender, Argument>> executions = new ArrayList<>();
 		// If this is executable, add its execution

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractArgumentTree.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractArgumentTree.java
@@ -60,6 +60,14 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 		return instance();
 	}
 
+	/**
+	 * Creates a chain of child branches starting at this node
+	 * <p>
+	 * {@code thenNested(a, b, c)} is equivalent to {@link #then}{@code (a.then(b.then(c)))}.
+	 *
+	 * @param trees The child branches to add in a chain.
+	 * @return this tree node
+	 */
 	@SafeVarargs
 	public final Impl thenNested(final AbstractArgumentTree<?, Argument, CommandSender>... trees) {
 		int length = trees.length;

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandTree.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandTree.java
@@ -19,7 +19,7 @@ extends AbstractCommandTree<Impl, Argument, CommandSender>
 /// @cond DOX
 extends AbstractArgument<?, ?, Argument, CommandSender>
 /// @endcond
-, 	CommandSender> extends ExecutableCommand<Impl, CommandSender> {
+, CommandSender> extends ExecutableCommand<Impl, CommandSender> {
 
 	private final List<AbstractArgumentTree<?, Argument, CommandSender>> arguments = new ArrayList<>();
 

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandTree.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandTree.java
@@ -19,7 +19,7 @@ extends AbstractCommandTree<Impl, Argument, CommandSender>
 /// @cond DOX
 extends AbstractArgument<?, ?, Argument, CommandSender>
 /// @endcond
-, CommandSender> extends ExecutableCommand<Impl, CommandSender> {
+, 	CommandSender> extends ExecutableCommand<Impl, CommandSender> {
 
 	private final List<AbstractArgumentTree<?, Argument, CommandSender>> arguments = new ArrayList<>();
 
@@ -41,6 +41,21 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 	public Impl then(final AbstractArgumentTree<?, Argument, CommandSender> tree) {
 		this.arguments.add(tree);
 		return instance();
+	}
+
+	@SafeVarargs
+	public final Impl thenNested(final AbstractArgumentTree<?, Argument, CommandSender>... trees) {
+		int length = trees.length;
+		if (length == 0) {
+			return instance();
+		}
+
+		AbstractArgumentTree<?, Argument, CommandSender> combined = trees[length - 1];
+		for (int i = length - 2; i >= 0; i--) {
+			combined = trees[i].then(combined);
+		}
+
+		return then(combined);
 	}
 
 	/**

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandTree.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/AbstractCommandTree.java
@@ -3,6 +3,7 @@ package dev.jorel.commandapi;
 import dev.jorel.commandapi.arguments.AbstractArgument;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -43,19 +44,39 @@ extends AbstractArgument<?, ?, Argument, CommandSender>
 		return instance();
 	}
 
-	@SafeVarargs
-	public final Impl thenNested(final AbstractArgumentTree<?, Argument, CommandSender>... trees) {
-		int length = trees.length;
+	/**
+	 * Creates a chain of child branches starting at this node
+	 * <p>
+	 * {@code thenNested(a, b, c)} is equivalent to {@link #then}{@code (a.then(b.then(c)))}.
+	 *
+	 * @param trees The child branches to add in a chain.
+	 * @return this tree node
+	 */
+	public final Impl thenNested(List<AbstractArgumentTree<?, Argument, CommandSender>> trees) {
+		int length = trees.size();
 		if (length == 0) {
 			return instance();
 		}
 
-		AbstractArgumentTree<?, Argument, CommandSender> combined = trees[length - 1];
+		AbstractArgumentTree<?, Argument, CommandSender> combined = trees.get(length - 1);
 		for (int i = length - 2; i >= 0; i--) {
-			combined = trees[i].then(combined);
+			combined = trees.get(i).then(combined);
 		}
 
 		return then(combined);
+	}
+
+	/**
+	 * Creates a chain of child branches starting at this node
+	 * <p>
+	 * {@code thenNested(a, b, c)} is equivalent to {@link #then}{@code (a.then(b.then(c)))}.
+	 *
+	 * @param trees The child branches to add in a chain.
+	 * @return this tree node
+	 */
+	@SafeVarargs
+	public final Impl thenNested(final AbstractArgumentTree<?, Argument, CommandSender>... trees) {
+		return thenNested(Arrays.asList(trees));
 	}
 
 	/**

--- a/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
+++ b/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
@@ -17,7 +17,7 @@ inline fun CommandTree.argument(base: Argument<*>, block: Argument<*>.() -> Unit
 
 inline fun CommandTree.optionalArgument(base: Argument<*>, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandTree = then(base.setOptional(true).setOptional(optional).apply(block))
 
-inline fun CommandTree.nestedArguments(vararg arguments: Argument<*>,block: Argument<*>.() -> Unit = {}): CommandTree = thenNested(*(arguments.also { it.last().apply(block) }))
+inline fun CommandTree.nestedArguments(vararg arguments: Argument<*>,block: Argument<*>.() -> Unit = {}): CommandTree = thenNested(*arguments.also { it.last().apply(block) })
 inline fun CommandTree.nested(block: CommandTree.() -> Unit): CommandTree {
 	val arguments = mutableListOf<AbstractArgumentTree<*, Argument<*>?, CommandSender?>?>()
 	object : CommandTree("commandWhichWontBeRegistered") {
@@ -135,7 +135,7 @@ inline fun Argument<*>.argument(base: Argument<*>, optional: Boolean = false, bl
 
 inline fun Argument<*>.optionalArgument(base: Argument<*>, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): Argument<*> = then(base.setOptional(true).setOptional(optional).apply(block))
 
-inline fun Argument<*>.nestedArguments(vararg arguments: Argument<*>, block: Argument<*>.() -> Unit = {}): Argument<*> = thenNested(*(arguments.also { it.last().apply(block) }))
+inline fun Argument<*>.nestedArguments(vararg arguments: Argument<*>, block: Argument<*>.() -> Unit = {}): Argument<*> = thenNested(*arguments.also { it.last().apply(block) })
 inline fun Argument<*>.nested(block: Argument<*>.() -> Unit): Argument<*> {
 	val arguments = mutableListOf<AbstractArgumentTree<*, Argument<*>?, CommandSender?>?>()
 	object : LiteralArgument("argumentWhichWontBeRegistered") {

--- a/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
+++ b/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
@@ -28,7 +28,7 @@ inline fun CommandTree.nested(block: CommandTree.() -> Unit): CommandTree {
 			return this
 		}
 	}.block()
-	return thenNested(*arguments.toTypedArray())
+	return thenNested(arguments)
 }
 
 // Integer arguments
@@ -146,7 +146,7 @@ inline fun Argument<*>.nested(block: Argument<*>.() -> Unit): Argument<*> {
 			return this
 		}
 	}.block()
-	return thenNested(*arguments.toTypedArray())
+	return thenNested(arguments)
 }
 
 // Integer arguments

--- a/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
+++ b/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
@@ -17,6 +17,18 @@ inline fun CommandTree.argument(base: Argument<*>, block: Argument<*>.() -> Unit
 
 inline fun CommandTree.optionalArgument(base: Argument<*>, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandTree = then(base.setOptional(true).setOptional(optional).apply(block))
 
+inline fun CommandTree.nestedArguments(vararg arguments: Argument<*>,block: Argument<*>.() -> Unit = {}): CommandTree = thenNested(*(arguments.also { it.last().apply(block) }))
+inline fun CommandTree.nested(block: CommandTree.() -> Unit): CommandTree {
+	val arguments = mutableListOf<AbstractArgumentTree<*, Argument<*>?, CommandSender?>?>()
+	object : CommandTree("commandWhichWontBeRegistered") {
+		override fun then(tree: AbstractArgumentTree<*, Argument<*>?, CommandSender?>?): CommandTree? {
+			arguments.add(tree)
+			return this
+		}
+	}.block()
+	return thenNested(*arguments.toTypedArray())
+}
+
 // Integer arguments
 inline fun CommandTree.integerArgument(nodeName: String, min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandTree = then(IntegerArgument(nodeName, min, max).setOptional(optional).apply(block))
 inline fun CommandTree.integerRangeArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandTree = then(IntegerRangeArgument(nodeName).setOptional(optional).apply(block))
@@ -122,6 +134,18 @@ inline fun CommandTree.functionArgument(nodeName: String, optional: Boolean = fa
 inline fun Argument<*>.argument(base: Argument<*>, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): Argument<*> = then(base.setOptional(optional).apply(block))
 
 inline fun Argument<*>.optionalArgument(base: Argument<*>, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): Argument<*> = then(base.setOptional(true).setOptional(optional).apply(block))
+
+inline fun Argument<*>.nestedArguments(vararg arguments: Argument<*>, block: Argument<*>.() -> Unit = {}): Argument<*> = thenNested(*(arguments.also { it.last().apply(block) }))
+inline fun Argument<*>.nested(block: Argument<*>.() -> Unit): Argument<*> {
+	val arguments = mutableListOf<AbstractArgumentTree<*, Argument<*>?, CommandSender?>?>()
+	object : LiteralArgument("argumentWhichWontBeRegistered") {
+		override fun then(tree: AbstractArgumentTree<*, Argument<*>?, CommandSender?>?): Argument<String?>? {
+			arguments.add(tree)
+			return this
+		}
+	}.block()
+	return thenNested(*arguments.toTypedArray())
+}
 
 // Integer arguments
 inline fun Argument<*>.integerArgument(nodeName: String, min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): Argument<*> = then(IntegerArgument(nodeName, min, max).setOptional(optional).apply(block))

--- a/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
+++ b/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
@@ -6,6 +6,8 @@ import org.bukkit.command.CommandSender
 import org.bukkit.plugin.java.JavaPlugin
 import java.util.function.Predicate
 
+const val WILL_NOT_REGISTER = "will-not-reg"
+
 inline fun commandTree(name: String, tree: CommandTree.() -> Unit = {}) = CommandTree(name).apply(tree).register()
 inline fun commandTree(name: String, namespace: String, tree: CommandTree.() -> Unit = {}) = CommandTree(name).apply(tree).register(namespace)
 inline fun commandTree(name: String, namespace: JavaPlugin, tree: CommandTree.() -> Unit = {}) = CommandTree(name).apply(tree).register(namespace)
@@ -20,7 +22,7 @@ inline fun CommandTree.optionalArgument(base: Argument<*>, optional: Boolean = f
 inline fun CommandTree.nestedArguments(vararg arguments: Argument<*>,block: Argument<*>.() -> Unit = {}): CommandTree = thenNested(*arguments.also { it.last().apply(block) })
 inline fun CommandTree.nested(block: CommandTree.() -> Unit): CommandTree {
 	val arguments = mutableListOf<AbstractArgumentTree<*, Argument<*>?, CommandSender?>?>()
-	object : CommandTree("commandWhichWontBeRegistered") {
+	object : CommandTree(WILL_NOT_REGISTER) {
 		override fun then(tree: AbstractArgumentTree<*, Argument<*>?, CommandSender?>?): CommandTree? {
 			arguments.add(tree)
 			return this
@@ -138,7 +140,7 @@ inline fun Argument<*>.optionalArgument(base: Argument<*>, optional: Boolean = f
 inline fun Argument<*>.nestedArguments(vararg arguments: Argument<*>, block: Argument<*>.() -> Unit = {}): Argument<*> = thenNested(*arguments.also { it.last().apply(block) })
 inline fun Argument<*>.nested(block: Argument<*>.() -> Unit): Argument<*> {
 	val arguments = mutableListOf<AbstractArgumentTree<*, Argument<*>?, CommandSender?>?>()
-	object : LiteralArgument("argumentWhichWontBeRegistered") {
+	object : LiteralArgument(WILL_NOT_REGISTER) {
 		override fun then(tree: AbstractArgumentTree<*, Argument<*>?, CommandSender?>?): Argument<String?>? {
 			arguments.add(tree)
 			return this

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-kotlin-test/src/test/kotlin/dev/jorel/commandapi/test/dsltests/CommandTreeTests.kt
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-kotlin-test/src/test/kotlin/dev/jorel/commandapi/test/dsltests/CommandTreeTests.kt
@@ -2,7 +2,6 @@ package dev.jorel.commandapi.test.dsltests
 
 import be.seeseemelk.mockbukkit.entity.PlayerMock
 import dev.jorel.commandapi.arguments.LiteralArgument
-import dev.jorel.commandapi.arguments.StringArgument
 import dev.jorel.commandapi.kotlindsl.commandTree
 import dev.jorel.commandapi.kotlindsl.literalArgument
 import dev.jorel.commandapi.kotlindsl.nested

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/CommandRegistrationTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/CommandRegistrationTests.java
@@ -707,4 +707,33 @@ class CommandRegistrationTests extends TestBase {
 			getDispatcherString()
 		);
 	}
+
+	@Test
+	void testCommandTreeThenNested() {
+		// Make sure dispatcher is cleared from any previous tests
+		CommandAPIHandler.getInstance().writeDispatcherToFile();
+
+		// Register a command using the legacy `then` method
+		new CommandTree("test1").then(
+			new LiteralArgument("a").then(
+				new LiteralArgument("b").then(
+					new LiteralArgument("c")
+						.executesPlayer(P_EXEC)
+				)
+			)
+		);
+		String dispatcherStrLegacy = getDispatcherString();
+
+		// Register a command using the new `thenNested` method
+		new CommandTree("test2").thenNested(
+			new LiteralArgument("a"),
+			new LiteralArgument("b"),
+			new LiteralArgument("c")
+				.executesPlayer(P_EXEC)
+		);
+		String dispatcherStrNested = getDispatcherString();
+
+		// Both commands should have the same dispatcher string
+		assertEquals(dispatcherStrLegacy, dispatcherStrNested);
+	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/CommandRegistrationTests.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/src/test/java/dev/jorel/commandapi/test/CommandRegistrationTests.java
@@ -713,27 +713,39 @@ class CommandRegistrationTests extends TestBase {
 		// Make sure dispatcher is cleared from any previous tests
 		CommandAPIHandler.getInstance().writeDispatcherToFile();
 
-		// Register a command using the legacy `then` method
-		new CommandTree("test1").then(
-			new LiteralArgument("a").then(
-				new LiteralArgument("b").then(
-					new LiteralArgument("c")
-						.executesPlayer(P_EXEC)
-				)
-			)
-		);
-		String dispatcherStrLegacy = getDispatcherString();
-
 		// Register a command using the new `thenNested` method
-		new CommandTree("test2").thenNested(
+		new CommandTree("test").thenNested(
 			new LiteralArgument("a"),
 			new LiteralArgument("b"),
 			new LiteralArgument("c")
 				.executesPlayer(P_EXEC)
-		);
-		String dispatcherStrNested = getDispatcherString();
+		).register();
 
-		// Both commands should have the same dispatcher string
-		assertEquals(dispatcherStrLegacy, dispatcherStrNested);
+		// Command added to tree
+		assertEquals("""
+			{
+			  "type": "root",
+			  "children": {
+			    "test": {
+			      "type": "literal",
+			      "children": {
+			        "a": {
+			          "type": "literal",
+			          "children": {
+			            "b": {
+			              "type": "literal",
+			              "children": {
+			                "c": {
+			                  "type": "literal",
+			                  "executable": true
+			                }
+			              }
+			            }
+			          }
+			        }
+			      }
+			    }
+			  }
+			}""", getDispatcherString());
 	}
 }

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -89,11 +89,11 @@ Sometimes we will need such a `CommandTree`:
 ```java,Java
 new CommandTree("example")
     .then(new LiteralArgument("arg1")
-    .then(new StringArgument("arg2")
-        .then(new StringArgument("arg3")
-            .then(new DoubleArgument("arg4", 0)
-                .then(new StringArgument("arg5"))
-                    .executes(...)))))
+        .then(new StringArgument("arg2")
+            .then(new StringArgument("arg3")
+                .then(new DoubleArgument("arg4", 0)
+                    .then(new StringArgument("arg5"))
+                        .executes(...)))))
     .register();
 ```
 

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -106,7 +106,7 @@ CommandTree("example")
                         .then(StringArgument("arg5")
                             .executes { ... })))))
     .register()
-``` 
+```
 
 ```kotlin,Kotlin DSL
 commandTree("example") {
@@ -141,7 +141,7 @@ new CommandTree("example")
             .executes(...)
     ) 
 ```
-    
+
 ```kotlin,Kotlin
 CommandTree("example")
     .thenNested(

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -108,7 +108,7 @@ CommandTree("example")
     .register()
 ```
 
-```kotlin,Kotlin DSL
+```kotlin,Kotlin_DSL
 commandTree("example") {
     literalArgument("arg1") {
         stringArgument("arg2") {

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -82,7 +82,7 @@ In this example, we have our normal `/sayhi` command using the `executes()` meth
 
 ### Reduce indentation with nested argument
 
-sometimes we will need such a CommandTree:
+Sometimes we will need such a `CommandTree`:
 
 <div class="multi-pre">
 

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -80,6 +80,108 @@ In this example, we have our normal `/sayhi` command using the `executes()` meth
 
 </div>
 
+### uses nested arguments to reduce indentation levels
+
+sometimes we will need such a CommandTree:
+
+<div class="multi-pre">
+
+```java,Java
+new CommandTree("example")
+    .then(new LiteralArgument("arg1")
+    .then(new StringArgument("arg2")
+        .then(new StringArgument("arg3")
+            .then(new DoubleArgument("arg4", 0)
+                .then(new StringArgument("arg5"))
+                    .executes(...)))))
+    .register();
+```
+
+```kotlin,Kotlin
+CommandTree("example")
+    .then(LiteralArgument("arg1")
+        .then(StringArgument("arg2")
+            .then(StringArgument("arg3")
+                    .then(DoubleArgument("arg4", 0)
+                        .then(StringArgument("arg5")
+                            .executes { ... })))))
+    .register()
+``` 
+
+```kotlin,Kotlin DSL
+commandTree("example") {
+    literalArgument("arg1") {
+        stringArgument("arg2") {
+            stringArgument("arg3") {
+                doubleArgument("arg4", 0.0) {
+                    stringArgument("arg5") {
+                        anyExecutor { ... }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+</div>
+
+well, there's too much indentation, we can use nested arguments to reduce the indentation levels:
+
+<div class="multi-pre">
+
+```java,Java
+new CommandTree("example")
+    .thenNested(
+        new LiteralArgument("arg1"),
+        new StringArgument("arg2"),
+        new StringArgument("arg3"),
+        new DoubleArgument("arg4", 0),
+        new StringArgument("arg5")
+            .executes(...)
+    ) 
+```
+    
+```kotlin,Kotlin
+CommandTree("example")
+    .thenNested(
+        LiteralArgument("arg1"),
+        StringArgument("arg2"),
+        StringArgument("arg3"),
+        DoubleArgument("arg4", 0),
+        StringArgument("arg5")
+            .executes { ... }
+    )
+```
+
+```kotlin,Kotlin DSL
+commandTree("example") {
+    nested {
+        literalArgument("arg1")
+        stringArgument("arg2")
+        stringArgument("arg3")
+        doubleArgument("arg4", 0.0)
+        stringArgument("arg5") {
+            anyExecutor { ... }
+        }
+    }
+}
+// or
+commandTree("example") {
+    nestedArguments(
+        LiteralArgument("arg1"),
+        StringArgument("arg2"),
+        StringArgument("arg3"),
+        DoubleArgument("arg4", 0.0),
+        StringArgument("arg5")
+    ) {
+        anyExecutor { ... }
+    }
+}
+```
+
+</div>
+
 -----
 
 That's effectively all of the basics of command trees! We start by writing a normal command, use `executes()` to make it executable and use `then()` to add additional paths to our command. Finally, we finish up with `register()` to register our command. Below, I've included a few more examples showcasing how to design commands using command trees.

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -126,7 +126,7 @@ commandTree("example") {
 
 </div>
 
-well, there's too much indentation, we can use nested arguments to reduce the indentation levels:
+Well, there's too much indentation. We can use nested arguments to reduce the indentation levels:
 
 <div class="multi-pre">
 

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -102,9 +102,9 @@ CommandTree("example")
     .then(LiteralArgument("arg1")
         .then(StringArgument("arg2")
             .then(StringArgument("arg3")
-                    .then(DoubleArgument("arg4", 0)
-                        .then(StringArgument("arg5")
-                            .executes { ... })))))
+                .then(DoubleArgument("arg4", 0)
+                    .then(StringArgument("arg5")
+                        .executes { ... })))))
     .register()
 ```
 

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -154,7 +154,7 @@ CommandTree("example")
     )
 ```
 
-```kotlin,Kotlin DSL
+```kotlin,Kotlin_DSL
 commandTree("example") {
     nested {
         literalArgument("arg1")

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -80,7 +80,7 @@ In this example, we have our normal `/sayhi` command using the `executes()` meth
 
 </div>
 
-### Reduce indentation with nested argument
+### Reduce indentation with nested arguments
 
 Sometimes we will need such a `CommandTree`:
 

--- a/docssrc/src/commandtrees.md
+++ b/docssrc/src/commandtrees.md
@@ -80,7 +80,7 @@ In this example, we have our normal `/sayhi` command using the `executes()` meth
 
 </div>
 
-### uses nested arguments to reduce indentation levels
+### Reduce indentation with nested argument
 
 sometimes we will need such a CommandTree:
 


### PR DESCRIPTION
Implemented the feature in #529 with Kotlin DSL support and changed the method name to 'thenNested' as suggested [in Discord](https://discord.com/channels/745416925924032523/745418987948736543/1304125456005595208)

 Usage: 

<details>

<summary>Java: </summary>

```java
new CommandTree("example")
    .thenNested(
        new LiteralArgument("arg1"),
        new StringArgument("arg2"),
        new StringArgument("arg3"),
        new DoubleArgument("arg4", 0),
        new StringArgument("arg5")
            .executes(...)
    ) 
```

</details>
<details>

<summary> Kotlin: </summary>

```kotlin
CommandTree("example")
    .thenNested(
        LiteralArgument("arg1"),
        StringArgument("arg2"),
        StringArgument("arg3"),
        DoubleArgument("arg4", 0),
        StringArgument("arg5")
            .executes { ... }
    )
```

</details>
<details>

<summary> Kotlin DSL</summary>

```kotlin
commandTree("example") {
    nested {
        literalArgument("arg1")
        stringArgument("arg2")
        stringArgument("arg3")
        doubleArgument("arg4", 0.0)
        stringArgument("arg5") {
            anyExecutor { ... }
        }
    }
}
// or
commandTree("example") {
    nestedArguments(
        LiteralArgument("arg1"),
        StringArgument("arg2"),
        StringArgument("arg3"),
        DoubleArgument("arg4", 0.0),
        StringArgument("arg5")
    ) {
        anyExecutor { ... }
    }
}
```
</details>