### PR TITLE
Fix registerCommand(Class<?>) with isolated class loaders

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPI.java
@@ -309,7 +309,8 @@ public class CommandAPI {
 	 */
 	public static void registerCommand(Class<?> commandClass) {
 		try {
-			Class.forName(commandClass.getName() + "$Command").getDeclaredMethod("register").invoke(null);
+			Class.forName(commandClass.getName() + "$Command", true, commandClass.getClassLoader())
+				.getDeclaredMethod("register").invoke(null);
 		} catch (ReflectiveOperationException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
The new Paper variant of CommandAPI is a Paper plugin (with the paper-plugin.yml definition) so it gets an isolated class loader that cannot load classes from other plugins. Therefore it will fail to load a class generated with the annotation processor (unless CommandAPI is shaded).

This simply uses the already existing class loader to get the class locally, which is easy as we're already getting a Class, not only a name.